### PR TITLE
Add reasoning-mode evaluation configs

### DIFF
--- a/eval_reasoning_checkpoints.sh
+++ b/eval_reasoning_checkpoints.sh
@@ -1,0 +1,37 @@
+#!/bin/bash
+set -euo pipefail
+
+if [[ $# -lt 1 ]]; then
+    echo "Usage: $0 <model_id> [model_id ...]" >&2
+    exit 1
+fi
+
+TASKS="ukrainian_bench_reasoning_api"
+INCLUDE_PATH="./tasks/ukrainian_bench_reasoning"
+OUTPUT_PATH="./eval-results-reasoning"
+GEN_KWARGS="temperature=0.7,top_p=0.95,until=<asdasdgfggvvcccx>,skip_special_tokens=False"
+
+export HF_DATASETS_TRUST_REMOTE_CODE=1
+export VLLM_WORKER_MULTIPROC_METHOD=spawn
+
+for CHECKPOINT in "$@"
+do
+   MODEL_ARGS="pretrained=${CHECKPOINT},data_parallel_size=1,tensor_parallel_size=1,gpu_memory_utilization=0.90,max_model_len=131072,max_num_seqs=128,max_num_batched_tokens=131072,add_bos_token=True,enable_thinking=True,trust_remote_code=True"
+   if [[ -n "${REASONING_PARSER:-}" ]]; then
+       MODEL_ARGS="${MODEL_ARGS},reasoning_parser=${REASONING_PARSER}"
+   fi
+
+   echo "Evaluating checkpoint: ${CHECKPOINT}"
+   echo "Tasks: ${TASKS}"
+   echo "GEN_KWARGS=${GEN_KWARGS}"
+   lm_eval run \
+       --model vllm \
+       --model_args "${MODEL_ARGS}" \
+       --tasks ${TASKS} \
+       --batch_size auto \
+       --gen_kwargs "${GEN_KWARGS}" \
+       --output_path "${OUTPUT_PATH}" \
+       --log_samples \
+       --include_path "${INCLUDE_PATH}" \
+       --apply_chat_template
+done

--- a/scripts/build_reasoning_aggregate.py
+++ b/scripts/build_reasoning_aggregate.py
@@ -1,0 +1,205 @@
+#!/usr/bin/env python3
+import argparse
+import copy
+import json
+from pathlib import Path
+from typing import Optional
+
+
+CANONICAL_TASKS = {
+    "arc_easy_uk_cot_likelihood": "arc_easy_uk",
+    "winogrande_uk_cot_likelihood": "winogrande_uk",
+    "belebele_ukr_Cyrl_cot_likelihood": "belebele_ukr_Cyrl",
+    "global_mmlu_full_uk_cot_likelihood": "global_mmlu_full_uk",
+    "squad_uk_cot_likelihood": "squad_uk",
+}
+
+METRIC_NORMALIZATION = {
+    "arc_challenge_uk": {
+        "exact_match,extract_answer": "exact_match,none",
+        "exact_match_stderr,extract_answer": "exact_match_stderr,none",
+    },
+    "wmt_en_uk": {
+        "bleu,extract_translation": "bleu,none",
+        "bleu_stderr,extract_translation": "bleu_stderr,none",
+    },
+    "flores_en-uk": {
+        "bleu,extract_translation": "bleu,none",
+        "bleu_stderr,extract_translation": "bleu_stderr,none",
+    },
+    "flores_uk-en": {
+        "bleu,extract_translation": "bleu,none",
+        "bleu_stderr,extract_translation": "bleu_stderr,none",
+    },
+    "long_flores_en-uk": {
+        "bleu,extract_translation": "bleu,none",
+        "bleu_stderr,extract_translation": "bleu_stderr,none",
+    },
+    "long_flores_uk-en": {
+        "bleu,extract_translation": "bleu,none",
+        "bleu_stderr,extract_translation": "bleu_stderr,none",
+    },
+    "zno_uk_geography": {
+        "exact,strict_letter": "exact,none",
+        "exact_stderr,strict_letter": "exact_stderr,none",
+    },
+    "zno_uk_history": {
+        "exact,strict_letter": "exact,none",
+        "exact_stderr,strict_letter": "exact_stderr,none",
+    },
+    "zno_uk_language_and_literature": {
+        "exact,strict_letter": "exact,none",
+        "exact_stderr,strict_letter": "exact_stderr,none",
+    },
+    "zno_uk_math": {
+        "exact,strict_letter": "exact,none",
+        "exact_stderr,strict_letter": "exact_stderr,none",
+    },
+}
+
+
+def read_json(path: Path) -> dict:
+    with open(path, encoding="utf-8") as f:
+        return json.load(f)
+
+
+def metric_value(result: dict, metric: str) -> float:
+    for key in (f"{metric},none", f"{metric},extract_translation", metric):
+        if key in result:
+            return result[key]
+    raise KeyError(f"Missing {metric} in {result.get('alias')}")
+
+
+def canonicalize_task(task: str) -> str:
+    return CANONICAL_TASKS.get(task, task)
+
+
+def normalize_metrics(task: str, result: dict) -> dict:
+    result = copy.deepcopy(result)
+    result["alias"] = task
+    for src, dst in METRIC_NORMALIZATION.get(task, {}).items():
+        if src in result:
+            result[dst] = result[src]
+    return result
+
+
+def portable_result_path(path: Path) -> str:
+    parts = path.parts
+    for i, part in enumerate(parts):
+        if part.startswith("eval-results"):
+            return str(Path(*parts[i:]))
+    return path.name
+
+
+def reasoning_model_name(source_docs: list[dict], explicit: Optional[str]) -> str:
+    if explicit:
+        return explicit
+    for doc in source_docs:
+        model_name = doc.get("model_name")
+        if model_name:
+            if "(reasoning)" in model_name:
+                return model_name
+            return f"{model_name} (reasoning)"
+    return "reasoning-model"
+
+
+def reasoning_model_name_sanitized(source_docs: list[dict], explicit: Optional[str]) -> str:
+    if explicit:
+        return explicit
+    for doc in source_docs:
+        model_name = doc.get("model_name_sanitized")
+        if model_name:
+            if model_name.endswith("-reasoning"):
+                return model_name
+            return f"{model_name}-reasoning"
+    return "reasoning-model"
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--output", required=True, type=Path)
+    parser.add_argument("--model-name")
+    parser.add_argument("--model-name-sanitized")
+    parser.add_argument("source_results", nargs="+", type=Path)
+    return parser.parse_args()
+
+
+def main() -> None:
+    args = parse_args()
+    source_docs = [read_json(path) for path in args.source_results]
+    aggregate = copy.deepcopy(source_docs[-1])
+    aggregate["results"] = {}
+    aggregate["groups"] = {}
+    aggregate["group_subtasks"] = {}
+    aggregate["configs"] = {}
+    aggregate["versions"] = {}
+    aggregate["n-shot"] = {}
+    aggregate["higher_is_better"] = {}
+    aggregate["n-samples"] = {}
+
+    for path, doc in zip(args.source_results, source_docs):
+        for source_task, source_result in doc.get("results", {}).items():
+            task = canonicalize_task(source_task)
+            if task.endswith("_reasoning_api"):
+                continue
+            result = normalize_metrics(task, source_result)
+            aggregate["results"][task] = result
+            aggregate["group_subtasks"][task] = []
+
+            config = copy.deepcopy(doc.get("configs", {}).get(source_task, {}))
+            config["task"] = task
+            config["alias"] = task
+            config.setdefault("metadata", {})
+            config["metadata"]["source_task"] = source_task
+            config["metadata"]["source_result_file"] = portable_result_path(path)
+            aggregate["configs"][task] = config
+
+            aggregate["versions"][task] = doc.get("versions", {}).get(source_task, 0)
+            aggregate["n-shot"][task] = doc.get("n-shot", {}).get(source_task, 0)
+            aggregate["higher_is_better"][task] = doc.get(
+                "higher_is_better", {}
+            ).get(source_task, {})
+            if source_task in doc.get("n-samples", {}):
+                aggregate["n-samples"][task] = doc["n-samples"][source_task]
+
+    if "flores_en-uk" in aggregate["results"] and "flores_uk-en" in aggregate["results"]:
+        aggregate["results"]["flores_uk"] = {
+            "alias": "flores_uk",
+            "bleu,none": (
+                metric_value(aggregate["results"]["flores_en-uk"], "bleu")
+                + metric_value(aggregate["results"]["flores_uk-en"], "bleu")
+            )
+            / 2,
+        }
+        aggregate["n-shot"]["flores_uk"] = 0
+        aggregate["higher_is_better"]["flores_uk"] = {"bleu": True}
+
+    if (
+        "long_flores_en-uk" in aggregate["results"]
+        and "long_flores_uk-en" in aggregate["results"]
+    ):
+        aggregate["results"]["long_flores_uk"] = {
+            "alias": "long_flores_uk",
+            "bleu,none": (
+                metric_value(aggregate["results"]["long_flores_en-uk"], "bleu")
+                + metric_value(aggregate["results"]["long_flores_uk-en"], "bleu")
+            )
+            / 2,
+        }
+        aggregate["n-shot"]["long_flores_uk"] = 0
+        aggregate["higher_is_better"]["long_flores_uk"] = {"bleu": True}
+
+    aggregate["model_name"] = reasoning_model_name(source_docs, args.model_name)
+    aggregate["model_name_sanitized"] = reasoning_model_name_sanitized(
+        source_docs, args.model_name_sanitized
+    )
+    aggregate["model_source"] = "vllm"
+    args.output.parent.mkdir(parents=True, exist_ok=True)
+    with open(args.output, "w", encoding="utf-8") as f:
+        json.dump(aggregate, f, ensure_ascii=False, indent=2)
+        f.write("\n")
+    print(args.output)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/generate_cot_traces.py
+++ b/scripts/generate_cot_traces.py
@@ -1,0 +1,219 @@
+#!/usr/bin/env python3
+import argparse
+import sys
+from pathlib import Path
+
+from datasets import Dataset
+from datasets import load_dataset
+from lm_eval import utils as lm_eval_utils
+from lm_eval.api.instance import Instance
+from lm_eval.api.registry import get_model
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+
+TASK_SPECS = {
+    "global_mmlu_full_uk": {
+        "dataset_path": "CohereForAI/Global-MMLU",
+        "dataset_name": "uk",
+        "split": "test",
+        "output": "cot_traces/global_mmlu_full_uk/global_mmlu_full_uk_cot.parquet",
+    },
+    "belebele_ukr_Cyrl": {
+        "dataset_path": "facebook/belebele",
+        "dataset_name": "ukr_Cyrl",
+        "split": "test",
+        "output": "cot_traces/belebele_ukr_Cyrl/belebele_ukr_Cyrl_cot.parquet",
+    },
+    "arc_easy_uk": {
+        "dataset_path": "INSAIT-Institute/arc-easy_ukr",
+        "dataset_name": None,
+        "split": "test",
+        "output": "cot_traces/arc_easy_uk/arc_easy_uk_cot.parquet",
+    },
+    "winogrande_uk": {
+        "dataset_path": "INSAIT-Institute/winogrande_ukr",
+        "dataset_name": None,
+        "split": "validation",
+        "output": "cot_traces/winogrande_uk/winogrande_uk_cot.parquet",
+    },
+    "squad_uk": {
+        "dataset_path": "FIdo-AI/ua-squad",
+        "dataset_name": None,
+        "split": "validation",
+        "output": "cot_traces/squad_uk/squad_uk_cot.parquet",
+    },
+}
+
+
+def labeled_options(labels: list[str], choices: list[str]) -> str:
+    return "\n".join(f"{label}. {choice}" for label, choice in zip(labels, choices))
+
+
+def winogrande_choices(doc: dict) -> list[str]:
+    idx = doc["sentence"].index("_")
+    return [
+        doc["sentence"][:idx] + doc["option1"],
+        doc["sentence"][:idx] + doc["option2"],
+    ]
+
+
+def build_user_prompt(task: str, doc: dict) -> str:
+    if task == "global_mmlu_full_uk":
+        choices = labeled_options(
+            ["A", "B", "C", "D"],
+            [doc["option_a"], doc["option_b"], doc["option_c"], doc["option_d"]],
+        )
+        answer_format = "<answer>LETTER</answer>, де LETTER - A, B, C або D"
+        return (
+            f"{doc['question'].strip()}\n"
+            f"{choices}\n\n"
+            "Поміркуй українською, який варіант є правильною відповіддю. "
+            f"Після міркування дай відповідь у форматі {answer_format}."
+        )
+
+    if task == "belebele_ukr_Cyrl":
+        choices = labeled_options(
+            ["1", "2", "3", "4"],
+            [doc["mc_answer1"], doc["mc_answer2"], doc["mc_answer3"], doc["mc_answer4"]],
+        )
+        return (
+            f"P: {doc['flores_passage']}\n"
+            f"Q: {doc['question'].strip()}\n"
+            f"{choices}\n\n"
+            "Поміркуй українською, який варіант є правильною відповіддю. "
+            "Після міркування дай відповідь у форматі <answer>N</answer>, "
+            "де N - номер правильного варіанта."
+        )
+
+    if task == "arc_easy_uk":
+        labels = doc["choices"]["label"]
+        choices = doc["choices"]["text"]
+        return (
+            f"Питання: {doc['question']}\n"
+            f"{labeled_options(labels, choices)}\n\n"
+            "Поміркуй українською, який варіант є правильною відповіддю. "
+            "Після міркування скопіюй текст правильної відповіді у форматі "
+            "<answer>текст відповіді</answer>."
+        )
+
+    if task == "winogrande_uk":
+        choices = [doc["option1"], doc["option2"]]
+        return (
+            f"Речення з пропуском: {doc['sentence']}\n"
+            f"{labeled_options(['1', '2'], choices)}\n\n"
+            "Поміркуй українською, який варіант правильно заповнює пропуск. "
+            "Після міркування скопіюй правильний варіант у форматі "
+            "<answer>варіант</answer>."
+        )
+
+    if task == "squad_uk":
+        return (
+            f"Контекст: {doc['Context']}\n\n"
+            f"Питання: {doc['Question']}\n\n"
+            "Знайди найкоротший фрагмент з контексту, який відповідає на питання.\n"
+            "Якщо відповідь не підтримується контекстом, виведи "
+            "<answer>немає відповіді</answer>.\n"
+            "Інакше виведи <answer>фрагмент з контексту</answer>."
+        )
+
+    raise ValueError(f"Unsupported task: {task}")
+
+
+def build_model_args(args) -> dict:
+    model_args = lm_eval_utils.simple_parse_args_string(args.model_args)
+    # Trace generation needs raw reasoning tokens, not parsed final answers.
+    model_args.pop("reasoning_parser", None)
+    model_args.pop("think_end_token", None)
+    return model_args
+
+
+def load_task_dataset(task: str):
+    if task == "squad_uk":
+        from tasks.ukrainian_bench.squad_uk.task import SQuAD2
+
+        squad_task = SQuAD2()
+        squad_task.download()
+        return Dataset.from_list(list(squad_task.validation_docs()))
+
+    spec = TASK_SPECS[task]
+    if spec["dataset_name"] is None:
+        return load_dataset(
+            spec["dataset_path"],
+            split=spec["split"],
+            trust_remote_code=True,
+        )
+    return load_dataset(
+        spec["dataset_path"],
+        spec["dataset_name"],
+        split=spec["split"],
+        trust_remote_code=True,
+    )
+
+
+def generate_with_lm_eval(docs, args) -> tuple[list[str], list[str]]:
+    lm = get_model(args.model).create_from_arg_obj(
+        build_model_args(args),
+        additional_config={"batch_size": "auto"},
+    )
+    gen_kwargs = {
+        "temperature": 0.7,
+        "top_p": 0.95,
+        "do_sample": True,
+        "max_gen_toks": args.max_gen_toks,
+        "until": ["<turn|>", "<|turn>"],
+        "skip_special_tokens": False,
+    }
+    prompts = build_stage1_chat_prompts(lm, args.task, docs)
+    requests = [
+        Instance(
+            request_type="generate_until",
+            doc=doc,
+            arguments=(prompt, gen_kwargs),
+            idx=0,
+            metadata=(f"{args.task}_cot_trace", i, 1),
+        )
+        for i, (doc, prompt) in enumerate(zip(docs, prompts))
+    ]
+    return [text.strip() for text in lm.generate_until(requests)], prompts
+
+
+def build_stage1_chat_prompts(lm, task: str, docs: list[dict]) -> list[str]:
+    return [
+        lm.apply_chat_template(
+            [{"role": "user", "content": build_user_prompt(task, doc)}],
+            add_generation_prompt=True,
+        )
+        for doc in docs
+    ]
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("task", choices=sorted(TASK_SPECS))
+    parser.add_argument("--model", default="vllm")
+    parser.add_argument("--model-args", required=True)
+    parser.add_argument("--output")
+    parser.add_argument("--limit", type=int, default=None)
+    parser.add_argument("--max-gen-toks", type=int, default=65536)
+    args = parser.parse_args()
+
+    ds = load_task_dataset(args.task)
+    if args.limit is not None:
+        ds = ds.select(range(min(args.limit, len(ds))))
+
+    docs = list(ds)
+    traces, chat_prompts = generate_with_lm_eval(docs, args)
+    ds = ds.add_column("stage1_chat_prompt", chat_prompts)
+    ds = ds.add_column("reasoning_trace", traces)
+    output = Path(args.output or TASK_SPECS[args.task]["output"])
+    output.parent.mkdir(parents=True, exist_ok=True)
+    ds.to_parquet(str(output))
+    print(f"Wrote {len(ds)} traces to {output}")
+
+
+if __name__ == "__main__":
+    main()

--- a/tasks/ukrainian_bench/zno_uk/zno_tasks.py
+++ b/tasks/ukrainian_bench/zno_uk/zno_tasks.py
@@ -1,4 +1,5 @@
 import re
+from copy import deepcopy
 from functools import partial
 from math import exp
 
@@ -34,7 +35,14 @@ class ZnoBaseTask(ConfigurableTask):
     DATASET_NAME = None
 
     def __init__(self, config=None):
-        super().__init__(config={"metadata": {"version": self.VERSION}})
+        config = deepcopy(config or {})
+        config.pop("class", None)
+        merged_config = {"metadata": {"version": self.VERSION}, **config}
+        merged_config["metadata"] = {
+            "version": self.VERSION,
+            **config.get("metadata", {}),
+        }
+        super().__init__(config=merged_config)
 
     def download(
         self,
@@ -65,6 +73,9 @@ class ZnoBaseTask(ConfigurableTask):
     
 
     def doc_to_text(self, doc):
+        if self.config.doc_to_text is not None:
+            return super().doc_to_text(doc)
+
         options = ["A", "B", "C", "D", "E"]
         options_text = "\n".join([f"{option}. {answer}" for option, answer in zip(options, doc["answers"])])
         return (
@@ -99,11 +110,16 @@ class ZnoBaseTask(ConfigurableTask):
             part of the document for `doc`.
         """
 
+        generation_kwargs = (
+            deepcopy(self.config.generation_kwargs)
+            if self.config.generation_kwargs is not None
+            else {"until": ["\n"]}
+        )
         return [
             Instance(
                 request_type="generate_until",
                 doc=doc,
-                arguments=(ctx, {"until": ["\n"]}),
+                arguments=(ctx, generation_kwargs),
                 idx=0,
                 **kwargs,
             ),

--- a/tasks/ukrainian_bench_reasoning/cot_likelihood/arc_easy_uk_cot_likelihood.yaml
+++ b/tasks/ukrainian_bench_reasoning/cot_likelihood/arc_easy_uk_cot_likelihood.yaml
@@ -1,0 +1,21 @@
+task: arc_easy_uk_cot_likelihood
+dataset_path: parquet
+dataset_kwargs:
+  data_files:
+    test: cot_traces/arc_easy_uk/arc_easy_uk_cot.parquet
+output_type: multiple_choice
+test_split: test
+doc_to_text: !function utils.arc_easy_doc_to_text_cot
+doc_to_target: !function utils.arc_easy_doc_to_target_index
+doc_to_choice: !function utils.arc_easy_doc_to_choice_text
+metric_list:
+  - metric: acc
+    aggregation: mean
+    higher_is_better: true
+  - metric: acc_norm
+    aggregation: mean
+    higher_is_better: true
+metadata:
+  version: 0.1
+  reasoning_mode: cot_conditioned_likelihood
+  stage2_trace_max_chars: 30000

--- a/tasks/ukrainian_bench_reasoning/cot_likelihood/belebele_ukr_Cyrl_cot_likelihood.yaml
+++ b/tasks/ukrainian_bench_reasoning/cot_likelihood/belebele_ukr_Cyrl_cot_likelihood.yaml
@@ -1,0 +1,21 @@
+task: belebele_ukr_Cyrl_cot_likelihood
+dataset_path: parquet
+dataset_kwargs:
+  data_files:
+    test: cot_traces/belebele_ukr_Cyrl/belebele_ukr_Cyrl_cot.parquet
+output_type: multiple_choice
+test_split: test
+doc_to_text: !function utils.belebele_doc_to_text_cot
+doc_to_target: !function utils.belebele_doc_to_target_index
+doc_to_choice: !function utils.belebele_doc_to_choice_numbers
+metric_list:
+  - metric: acc
+    aggregation: mean
+    higher_is_better: true
+  - metric: acc_norm
+    aggregation: mean
+    higher_is_better: true
+metadata:
+  version: 0.1
+  reasoning_mode: cot_conditioned_likelihood
+  stage2_trace_max_chars: 30000

--- a/tasks/ukrainian_bench_reasoning/cot_likelihood/global_mmlu_full_uk_cot_likelihood.yaml
+++ b/tasks/ukrainian_bench_reasoning/cot_likelihood/global_mmlu_full_uk_cot_likelihood.yaml
@@ -1,0 +1,18 @@
+task: global_mmlu_full_uk_cot_likelihood
+dataset_path: parquet
+dataset_kwargs:
+  data_files:
+    test: cot_traces/global_mmlu_full_uk/global_mmlu_full_uk_cot.parquet
+output_type: multiple_choice
+test_split: test
+doc_to_text: !function utils.global_mmlu_doc_to_text_cot
+doc_to_target: !function utils.global_mmlu_doc_to_target_letter
+doc_to_choice: !function utils.global_mmlu_doc_to_choice_letters
+metric_list:
+  - metric: acc
+    aggregation: mean
+    higher_is_better: true
+metadata:
+  version: 0.1
+  reasoning_mode: cot_conditioned_likelihood
+  stage2_trace_max_chars: 30000

--- a/tasks/ukrainian_bench_reasoning/cot_likelihood/squad_uk_cot.py
+++ b/tasks/ukrainian_bench_reasoning/cot_likelihood/squad_uk_cot.py
@@ -1,0 +1,108 @@
+import math
+import sys
+from functools import partial
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+TASK_DIR = Path(__file__).resolve().parent
+if str(TASK_DIR) not in sys.path:
+    sys.path.insert(0, str(TASK_DIR))
+
+from lm_eval.api.instance import Instance
+from lm_eval.api.task import ConfigurableTask
+from tasks.ukrainian_bench.squad_uk.task import _squad_agg
+
+import utils
+
+
+class SQuAD2CotLikelihood(ConfigurableTask):
+    VERSION = "0.1"
+    NO_ANSWER = "немає"
+    HAS_ANSWER = "є"
+
+    def __init__(self, config=None):
+        config = dict(config or {})
+        config.pop("class", None)
+        super().__init__(config=config)
+
+    def doc_to_text(self, doc, doc_to_text=None):
+        return utils.squad_doc_to_text_cot(doc)
+
+    def doc_to_target(self, doc, doc_to_target=None):
+        return self.NO_ANSWER if len(doc["Answer"]["text"]) == 0 else self.HAS_ANSWER
+
+    def construct_requests(self, doc, ctx, **kwargs):
+        kwargs.pop("apply_chat_template", None)
+        kwargs.pop("chat_template", None)
+        return [
+            Instance(
+                request_type="loglikelihood",
+                doc=doc,
+                arguments=(ctx, self.NO_ANSWER),
+                idx=0,
+                **kwargs,
+            ),
+            Instance(
+                request_type="loglikelihood",
+                doc=doc,
+                arguments=(ctx, self.HAS_ANSWER),
+                idx=1,
+                **kwargs,
+            ),
+        ]
+
+    def process_results(self, doc, results):
+        (logprob_no_answer, _), (logprob_has_answer, _) = results
+        max_logprob = max(logprob_no_answer, logprob_has_answer)
+        denom = max_logprob + math.log(
+            math.exp(logprob_no_answer - max_logprob)
+            + math.exp(logprob_has_answer - max_logprob)
+        )
+        no_answer_probability = math.exp(logprob_no_answer - denom)
+
+        predictions = {
+            "id": doc["id"],
+            "prediction_text": utils.squad_prediction_from_trace(doc),
+            "no_answer_probability": no_answer_probability,
+        }
+        references = {
+            "id": doc["id"],
+            "answers": doc["Answer"],
+        }
+        pair = (predictions, references)
+        return {
+            "exact": pair,
+            "f1": pair,
+            "HasAns_exact": pair,
+            "HasAns_f1": pair,
+            "NoAns_exact": pair,
+            "NoAns_f1": pair,
+            "best_exact": pair,
+            "best_f1": pair,
+        }
+
+    def aggregation(self):
+        return {
+            "exact": partial(_squad_agg, "exact"),
+            "f1": partial(_squad_agg, "f1"),
+            "HasAns_exact": partial(_squad_agg, "HasAns_exact"),
+            "HasAns_f1": partial(_squad_agg, "HasAns_f1"),
+            "NoAns_exact": partial(_squad_agg, "NoAns_exact"),
+            "NoAns_f1": partial(_squad_agg, "NoAns_f1"),
+            "best_exact": partial(_squad_agg, "best_exact"),
+            "best_f1": partial(_squad_agg, "best_f1"),
+        }
+
+    def higher_is_better(self):
+        return {
+            "exact": True,
+            "f1": True,
+            "HasAns_exact": True,
+            "HasAns_f1": True,
+            "NoAns_exact": True,
+            "NoAns_f1": True,
+            "best_exact": True,
+            "best_f1": True,
+        }

--- a/tasks/ukrainian_bench_reasoning/cot_likelihood/squad_uk_cot_likelihood.yaml
+++ b/tasks/ukrainian_bench_reasoning/cot_likelihood/squad_uk_cot_likelihood.yaml
@@ -1,0 +1,13 @@
+task: squad_uk_cot_likelihood
+class: !function squad_uk_cot.SQuAD2CotLikelihood
+dataset_path: parquet
+dataset_kwargs:
+  data_files:
+    validation: cot_traces/squad_uk/squad_uk_cot.parquet
+output_type: loglikelihood
+validation_split: validation
+test_split: validation
+metadata:
+  version: 0.1
+  reasoning_mode: cot_conditioned_likelihood
+  stage2_trace_max_chars: 30000

--- a/tasks/ukrainian_bench_reasoning/cot_likelihood/utils.py
+++ b/tasks/ukrainian_bench_reasoning/cot_likelihood/utils.py
@@ -1,0 +1,129 @@
+import os
+import re
+
+
+def _trace_prefix(doc) -> str:
+    raw_trace = doc.get("reasoning_trace", "").strip()
+    if raw_trace:
+        answer_start = raw_trace.rfind("<channel|><answer>")
+        if answer_start >= 0:
+            answer_start += len("<channel|>")
+        else:
+            answer_start = raw_trace.rfind("<answer>")
+        if answer_start >= 0:
+            raw_trace = raw_trace[:answer_start].rstrip()
+    max_chars = int(os.environ.get("COT_TRACE_MAX_CHARS", "0") or 0)
+    if max_chars > 0 and len(raw_trace) > max_chars:
+        raw_trace = raw_trace[:max_chars].rstrip()
+    return raw_trace
+
+
+def _append_trace(prompt: str, doc) -> str:
+    prompt = doc.get("stage1_chat_prompt") or prompt
+    raw_trace = _trace_prefix(doc)
+    if raw_trace:
+        prompt += "\n\n" + raw_trace
+    return prompt + "\n\n<answer>"
+
+
+def global_mmlu_doc_to_text_cot(doc) -> str:
+    prompt = (
+        f"{doc['question'].strip()}\n"
+        f"A. {doc['option_a']}\n"
+        f"B. {doc['option_b']}\n"
+        f"C. {doc['option_c']}\n"
+        f"D. {doc['option_d']}"
+    )
+    return _append_trace(prompt, doc)
+
+
+def global_mmlu_doc_to_choice_letters(doc) -> list[str]:
+    return ["A", "B", "C", "D"]
+
+
+def global_mmlu_doc_to_target_letter(doc) -> str:
+    return doc["answer"]
+
+
+def belebele_doc_to_text_cot(doc) -> str:
+    prompt = (
+        f"P: {doc['flores_passage']}\n"
+        f"Q: {doc['question'].strip()}\n"
+        f"1. {doc['mc_answer1']}\n"
+        f"2. {doc['mc_answer2']}\n"
+        f"3. {doc['mc_answer3']}\n"
+        f"4. {doc['mc_answer4']}"
+    )
+    return _append_trace(prompt, doc)
+
+
+def belebele_doc_to_choice_numbers(doc) -> list[str]:
+    return ["1", "2", "3", "4"]
+
+
+def belebele_doc_to_target_index(doc) -> int:
+    return int(doc["correct_answer_num"]) - 1
+
+
+def arc_easy_doc_to_text_cot(doc) -> str:
+    labels = doc["choices"]["label"]
+    choices = doc["choices"]["text"]
+    options = "\n".join(f"{label}. {choice}" for label, choice in zip(labels, choices))
+    prompt = f"Питання: {doc['question']}\n{options}"
+    return _append_trace(prompt, doc)
+
+
+def arc_easy_doc_to_choice_text(doc) -> list[str]:
+    return doc["choices"]["text"]
+
+
+def arc_easy_doc_to_target_index(doc) -> int:
+    return doc["choices"]["label"].index(doc["answerKey"])
+
+
+def winogrande_doc_to_text_cot(doc) -> str:
+    prompt = (
+        f"Речення з пропуском: {doc['sentence']}\n"
+        f"1. {doc['option1']}\n"
+        f"2. {doc['option2']}"
+    )
+    return _append_trace(prompt, doc)
+
+
+def winogrande_doc_to_choice_options(doc) -> list[str]:
+    return [doc["option1"], doc["option2"]]
+
+
+def winogrande_doc_to_target_index(doc) -> int:
+    return int(doc["answer"]) - 1
+
+
+def squad_doc_to_text_cot(doc) -> str:
+    prompt = doc.get("stage1_chat_prompt") or (
+        f"Контекст: {doc['Context']}\n\n"
+        f"Питання: {doc['Question']}\n\n"
+        "Знайди найкоротший фрагмент з контексту, який відповідає на питання.\n"
+        "Якщо відповідь не підтримується контекстом, виведи "
+        "<answer>немає відповіді</answer>.\n"
+        "Інакше виведи <answer>фрагмент з контексту</answer>."
+    )
+    trace = _trace_prefix(doc)
+    if trace:
+        prompt += "\n\n" + trace
+    return (
+        prompt
+        + "\n\nПісля наведеного міркування визнач, чи є відповідь у контексті.\n"
+        "Виведи лише одне слово: немає або є.\n\n"
+        "<answer_status>"
+    )
+
+
+def squad_prediction_from_trace(doc) -> str:
+    trace = doc.get("reasoning_trace", "")
+    matches = re.findall(r"<answer>(.*?)</answer>", trace, flags=re.DOTALL)
+    if not matches:
+        return ""
+    answer = matches[-1].strip()
+    if answer.casefold() == "немає відповіді":
+        return ""
+    return answer

--- a/tasks/ukrainian_bench_reasoning/cot_likelihood/winogrande_uk_cot_likelihood.yaml
+++ b/tasks/ukrainian_bench_reasoning/cot_likelihood/winogrande_uk_cot_likelihood.yaml
@@ -1,0 +1,19 @@
+task: winogrande_uk_cot_likelihood
+dataset_path: parquet
+dataset_kwargs:
+  data_files:
+    validation: cot_traces/winogrande_uk/winogrande_uk_cot.parquet
+output_type: multiple_choice
+validation_split: validation
+test_split: validation
+doc_to_text: !function utils.winogrande_doc_to_text_cot
+doc_to_target: !function utils.winogrande_doc_to_target_index
+doc_to_choice: !function utils.winogrande_doc_to_choice_options
+metric_list:
+  - metric: acc
+    aggregation: mean
+    higher_is_better: true
+metadata:
+  version: 0.1
+  reasoning_mode: cot_conditioned_likelihood
+  stage2_trace_max_chars: 30000

--- a/tasks/ukrainian_bench_reasoning/overrides/arc_challenge_uk.yaml
+++ b/tasks/ukrainian_bench_reasoning/overrides/arc_challenge_uk.yaml
@@ -1,0 +1,17 @@
+include: ../../ukrainian_bench/arc-challenge_uk/arc_challenge_uk.yaml
+task: arc_challenge_uk
+task_alias: arc_challenge_uk
+doc_to_text: 'Маючи наступне запитання та чотири варіанти відповіді (A, B, C and D), оберіть найкращу відповідь.\nПитання: {{question.strip()}}\nA. {{choices.text[0]}}\nB. {{choices.text[1]}}\nC. {{choices.text[2]}}{% if choices.text|length > 3 %}\nD. {{choices.text[3]}}{% endif %}\nВиведи лише фінальну відповідь у форматі "Найкраща відповідь — X", де X — це одна з A, B, C або D.'
+gen_prefix: 'Найкраща відповідь — '
+generation_kwargs:
+  max_gen_toks: 16384
+  until:
+    - "==sdfAcxbvgg/=/=/="
+filter_list:
+  - name: extract_answer
+    filter:
+      - function: regex
+        group_select: -1
+        regex_pattern: '(?is)(?:Найкраща\s+відповідь\s*[—:-]\s*([ABCD]))|(?:^\s*([ABCD])\b)'
+        fallback: "[invalid]"
+      - function: take_first

--- a/tasks/ukrainian_bench_reasoning/overrides/flores_en-uk.yaml
+++ b/tasks/ukrainian_bench_reasoning/overrides/flores_en-uk.yaml
@@ -1,0 +1,16 @@
+include: ../../ukrainian_bench/flores_uk/flores_en-uk.yaml
+task: flores_en-uk
+task_alias: flores_en-uk
+doc_to_text: "Translate this sentence into Ukrainian:\n{{sentence_eng_Latn}}\n\nResponse format must be <translation>переклад українською</translation>."
+generation_kwargs:
+  max_gen_toks: 65536
+  until:
+    - "==sdfAcxbvgg/=/=/="
+filter_list:
+  - name: extract_translation
+    filter:
+      - function: regex
+        regex_pattern: '(?s)<translation>\s*(.*?)\s*</translation>'
+        group_select: 0
+        fallback: ""
+      - function: take_first

--- a/tasks/ukrainian_bench_reasoning/overrides/flores_uk-en.yaml
+++ b/tasks/ukrainian_bench_reasoning/overrides/flores_uk-en.yaml
@@ -1,0 +1,16 @@
+include: ../../ukrainian_bench/flores_uk/flores_uk-en.yaml
+task: flores_uk-en
+task_alias: flores_uk-en
+doc_to_text: "Translate this sentence into English:\n{{sentence_ukr_Cyrl}}\n\nResponse format must be <translation>English translation</translation>."
+generation_kwargs:
+  max_gen_toks: 65536
+  until:
+    - "==sdfAcxbvgg/=/=/="
+filter_list:
+  - name: extract_translation
+    filter:
+      - function: regex
+        regex_pattern: '(?s)<translation>\s*(.*?)\s*</translation>'
+        group_select: 0
+        fallback: ""
+      - function: take_first

--- a/tasks/ukrainian_bench_reasoning/overrides/gsm8k_uk.yaml
+++ b/tasks/ukrainian_bench_reasoning/overrides/gsm8k_uk.yaml
@@ -1,0 +1,10 @@
+include: ../../ukrainian_bench/gsm8k_uk/gsm8k_uk.yaml
+task: gsm8k_uk
+task_alias: gsm8k_uk
+doc_to_text: "Питання: {{question}}\nРозв'яжи задачу покроково. Останній рядок виведи рівно у форматі: The answer is N. Не пропускай фінальну крапку.\nВідповідь:"
+generation_kwargs:
+  max_gen_toks: 65536
+  until:
+    - "==sdfAcxbvgg/=/=/="
+  do_sample: false
+  temperature: 0.0

--- a/tasks/ukrainian_bench_reasoning/overrides/ifeval_uk.yaml
+++ b/tasks/ukrainian_bench_reasoning/overrides/ifeval_uk.yaml
@@ -1,0 +1,6 @@
+include: ../../ukrainian_bench/ifeval_uk/ifeval_uk.yaml
+task: ifeval_uk
+task_alias: ifeval_uk
+doc_to_text: "Виконай інструкцію нижче буквально. Не додавай вступу чи пояснень поза вимогами.\n\n{{prompt}}"
+generation_kwargs:
+  max_gen_toks: 65536

--- a/tasks/ukrainian_bench_reasoning/overrides/long_flores_en-uk.yaml
+++ b/tasks/ukrainian_bench_reasoning/overrides/long_flores_en-uk.yaml
@@ -1,0 +1,16 @@
+include: ../../ukrainian_bench/long_flores_uk/long_flores_en-uk.yaml
+task: long_flores_en-uk
+task_alias: long_flores_en-uk
+doc_to_text: "Translate this text into Ukrainian:\n{{sentence_eng_Latn}}\n\nResponse format must be <translation>переклад українською</translation>."
+generation_kwargs:
+  max_gen_toks: 65536
+  until:
+    - "==sdfAcxbvgg/=/=/="
+filter_list:
+  - name: extract_translation
+    filter:
+      - function: regex
+        regex_pattern: '(?s)<translation>\s*(.*?)\s*</translation>'
+        group_select: 0
+        fallback: ""
+      - function: take_first

--- a/tasks/ukrainian_bench_reasoning/overrides/long_flores_uk-en.yaml
+++ b/tasks/ukrainian_bench_reasoning/overrides/long_flores_uk-en.yaml
@@ -1,0 +1,16 @@
+include: ../../ukrainian_bench/long_flores_uk/long_flores_uk-en.yaml
+task: long_flores_uk-en
+task_alias: long_flores_uk-en
+doc_to_text: "Translate this text into English:\n{{sentence_ukr_Cyrl}}\n\nResponse format must be <translation>English translation</translation>."
+generation_kwargs:
+  max_gen_toks: 65536
+  until:
+    - "==sdfAcxbvgg/=/=/="
+filter_list:
+  - name: extract_translation
+    filter:
+      - function: regex
+        regex_pattern: '(?s)<translation>\s*(.*?)\s*</translation>'
+        group_select: 0
+        fallback: ""
+      - function: take_first

--- a/tasks/ukrainian_bench_reasoning/overrides/triviaqa_uk.yaml
+++ b/tasks/ukrainian_bench_reasoning/overrides/triviaqa_uk.yaml
@@ -1,0 +1,10 @@
+include: ../../ukrainian_bench/trivia_qa_uk/triviaqa_uk.yaml
+task: triviaqa_uk
+task_alias: triviaqa_uk
+doc_to_text: "Питання: {{question.rstrip('?')}}?\nДай лише точне ім'я або назву, без пояснень. Не перекладай власні назви, якщо це не потрібно.\nВідповідь:"
+generation_kwargs:
+  max_gen_toks: 8192
+  until:
+    - "==sdfAcxbvgg/=/=/="
+  do_sample: false
+  temperature: 0.0

--- a/tasks/ukrainian_bench_reasoning/overrides/wmt_en_uk.yaml
+++ b/tasks/ukrainian_bench_reasoning/overrides/wmt_en_uk.yaml
@@ -1,0 +1,16 @@
+include: ../../ukrainian_bench/wmt_en_uk/wmt_en_uk.yaml
+task: wmt_en_uk
+task_alias: wmt_en_uk
+doc_to_text: "Translate this text into Ukrainian:\n{{source}}\n\nResponse format must be <translation>переклад українською</translation>."
+generation_kwargs:
+  max_gen_toks: 65536
+  until:
+    - "==sdfAcxbvgg/=/=/="
+filter_list:
+  - name: extract_translation
+    filter:
+      - function: regex
+        regex_pattern: '(?s)<translation>\s*(.*?)\s*</translation>'
+        group_select: 0
+        fallback: ""
+      - function: take_first

--- a/tasks/ukrainian_bench_reasoning/overrides/xlsum_uk.yaml
+++ b/tasks/ukrainian_bench_reasoning/overrides/xlsum_uk.yaml
@@ -1,0 +1,10 @@
+include: ../../ukrainian_bench/xlsum_uk/xlsum_uk.yaml
+task: xlsum_uk
+task_alias: xlsum_uk
+doc_to_text: "Текст: {{text}}\n\nНапиши один короткий підсумок українською. Лише головний факт. Без префіксів, заголовка чи пояснень."
+generation_kwargs:
+  max_gen_toks: 65536
+  until:
+    - "==sdfAcxbvgg/=/=/="
+  do_sample: false
+  temperature: 0.0

--- a/tasks/ukrainian_bench_reasoning/overrides/zno_uk_geography.yaml
+++ b/tasks/ukrainian_bench_reasoning/overrides/zno_uk_geography.yaml
@@ -1,0 +1,18 @@
+include: ../../ukrainian_bench/zno_uk/zno_uk_geography.yaml
+task: zno_uk_geography
+task_alias: zno_uk_geography
+doc_to_text: "Питання: {{question.strip()}}\n{% for answer in answers %}{{ 'ABCDE'[loop.index0] }}. {{answer}}\n{% endfor %}Виведи лише одну латинську літеру правильної відповіді: A, B, C, D або E. Без пояснень.\nВідповідь:"
+filter_list:
+  - name: strict_letter
+    filter:
+      - function: regex
+        regex_pattern: '^\s*([ABCDE])\s*$'
+        group_select: 0
+        fallback: "[invalid]"
+      - function: take_first
+generation_kwargs:
+  max_gen_toks: 65536
+  until:
+    - "==sdfAcxbvgg/=/=/="
+  do_sample: false
+  temperature: 0.0

--- a/tasks/ukrainian_bench_reasoning/overrides/zno_uk_history.yaml
+++ b/tasks/ukrainian_bench_reasoning/overrides/zno_uk_history.yaml
@@ -1,0 +1,18 @@
+include: ../../ukrainian_bench/zno_uk/zno_uk_history.yaml
+task: zno_uk_history
+task_alias: zno_uk_history
+doc_to_text: "Питання: {{question.strip()}}\n{% for answer in answers %}{{ 'ABCDE'[loop.index0] }}. {{answer}}\n{% endfor %}Виведи лише одну латинську літеру правильної відповіді: A, B, C, D або E. Без пояснень.\nВідповідь:"
+filter_list:
+  - name: strict_letter
+    filter:
+      - function: regex
+        regex_pattern: '^\s*([ABCDE])\s*$'
+        group_select: 0
+        fallback: "[invalid]"
+      - function: take_first
+generation_kwargs:
+  max_gen_toks: 65536
+  until:
+    - "==sdfAcxbvgg/=/=/="
+  do_sample: false
+  temperature: 0.0

--- a/tasks/ukrainian_bench_reasoning/overrides/zno_uk_language_and_literature.yaml
+++ b/tasks/ukrainian_bench_reasoning/overrides/zno_uk_language_and_literature.yaml
@@ -1,0 +1,18 @@
+include: ../../ukrainian_bench/zno_uk/zno_uk_language_and_literature.yaml
+task: zno_uk_language_and_literature
+task_alias: zno_uk_language_and_literature
+doc_to_text: "Питання: {{question.strip()}}\n{% for answer in answers %}{{ 'ABCDE'[loop.index0] }}. {{answer}}\n{% endfor %}Виведи лише одну латинську літеру правильної відповіді: A, B, C, D або E. Без пояснень.\nВідповідь:"
+filter_list:
+  - name: strict_letter
+    filter:
+      - function: regex
+        regex_pattern: '^\s*([ABCDE])\s*$'
+        group_select: 0
+        fallback: "[invalid]"
+      - function: take_first
+generation_kwargs:
+  max_gen_toks: 65536
+  until:
+    - "==sdfAcxbvgg/=/=/="
+  do_sample: false
+  temperature: 0.0

--- a/tasks/ukrainian_bench_reasoning/overrides/zno_uk_math.yaml
+++ b/tasks/ukrainian_bench_reasoning/overrides/zno_uk_math.yaml
@@ -1,0 +1,18 @@
+include: ../../ukrainian_bench/zno_uk/zno_uk_math.yaml
+task: zno_uk_math
+task_alias: zno_uk_math
+doc_to_text: "Питання: {{question.strip()}}\n{% for answer in answers %}{{ 'ABCDE'[loop.index0] }}. {{answer}}\n{% endfor %}Виведи лише одну латинську літеру правильної відповіді: A, B, C, D або E. Без пояснень.\nВідповідь:"
+filter_list:
+  - name: strict_letter
+    filter:
+      - function: regex
+        regex_pattern: '^\s*([ABCDE])\s*$'
+        group_select: 0
+        fallback: "[invalid]"
+      - function: take_first
+generation_kwargs:
+  max_gen_toks: 65536
+  until:
+    - "==sdfAcxbvgg/=/=/="
+  do_sample: false
+  temperature: 0.0

--- a/tasks/ukrainian_bench_reasoning/ukrainian_bench_reasoning_api.yaml
+++ b/tasks/ukrainian_bench_reasoning/ukrainian_bench_reasoning_api.yaml
@@ -1,0 +1,19 @@
+group: ukrainian_bench_reasoning_api
+group_alias: ukrainian_bench_reasoning_api
+task:
+  - triviaqa_uk
+  - arc_challenge_uk
+  - gsm8k_uk
+  - ifeval_uk
+  - wmt_en_uk
+  - flores_en-uk
+  - flores_uk-en
+  - long_flores_en-uk
+  - long_flores_uk-en
+  - xlsum_uk
+  - zno_uk_geography
+  - zno_uk_history
+  - zno_uk_language_and_literature
+  - zno_uk_math
+metadata:
+  version: 1.0


### PR DESCRIPTION
Adds a reproducible reasoning-mode evaluation path for Ukrainian Bench.

This PR adds:
- a reasoning task group with prompt/generation overrides for generation-based tasks;
- a small CoT-conditioned likelihood pipeline for selected loglikelihood tasks;
- helper scripts for running reasoning evaluations and building an aggregate result file;
- a small ZNO adapter fix so inline YAML overrides and generation kwargs are respected.

Result JSONs are intentionally not included here; they are submitted separately to the leaderboard results dataset.