### PR TITLE
Add Ukrainian fairness leaderboard

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ The data comes from evaluation results [lang-uk/ukrainian-llm-leaderboard-result
 
 ## 📏 What does it measure?
 The leaderboard evaluates models on a variety of benchmarks covering different NLP tasks in Ukrainian, including:
+- ⚖️ **Fairness**: StereoSet-UK Eval, with WinoBias, WinoGender, BBQ, and CrowS-Pairs planned
 - 🌐 **Machine Translation**: FLORES-200 (en-uk, uk-en), LongFLORES (en-uk, uk-en), WMT-22 (en-uk, uk-en)
 - 📌 **Summarization**: XLSUM (uk)
 - 🔎 **In-Context Question Answering**: Belebele (uk), SQuAD (uk)
@@ -52,11 +53,14 @@ If you want to leave a feedback or suggest a new feature, please open an issue o
 ### How to Use
 
 - **Main Leaderboard**: View performance on core benchmarks
+- **Fairness**: View bias and fairness metrics. Current StereoSet-UK Eval results cover a provisional 949-item subset.
 - **Detailed Benchmarks**: Explore performance on specific benchmark categories
 - **Model Comparison**: Compare multiple models with radar charts
 - **Visualizations**: Generate bar charts for specific metrics
 
 Sort tables by any metric and adjust display options using the controls.
+
+Fairness results are loaded from `eval-results/fairness`, which comes from the separate leaderboard results dataset. Each model has one JSON file. Benchmarks appear as tabs, metrics appear as columns, and available bias-type breakdowns receive separate rankings.
 
 ### ᯓ🏃🏻‍♀️‍➡️ How to Run Benchmarks
 

--- a/fairness.py
+++ b/fairness.py
@@ -1,0 +1,253 @@
+import json
+import math
+from collections import Counter
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+import gradio as gr
+import pandas as pd
+
+FAIRNESS_BENCHMARK_METRICS = {
+    "StereoSet-UK Eval": ("LMS ↑", "SS → 50", "ICAT ↑"),
+    "WinoBias-UK": (
+        "Type 1 F1 ↑",
+        "Type 1 pro/anti gap → 0",
+        "Type 2 F1 ↑",
+        "Type 2 pro/anti gap → 0",
+    ),
+    "WinoGender-UK": (
+        "Accuracy ↑",
+        "Gender accuracy gap → 0",
+    ),
+    "BBQ-UK": (
+        "Ambiguous accuracy ↑",
+        "Disambiguated accuracy ↑",
+        "Ambiguous bias → 0",
+        "Disambiguated bias → 0",
+    ),
+    "CrowS-Pairs-UK": ("Stereotype score → 50",),
+}
+
+
+@dataclass(frozen=True)
+class FairnessRanking:
+    metric: str
+    goal: str
+    target: float | None = None
+
+
+@dataclass
+class FairnessBenchmark:
+    ranking: FairnessRanking
+    overall_rows: list[dict[str, str | int | float]]
+    bias_type_rows: list[dict[str, str | int | float]]
+
+
+def create_ranked_fairness_dataframe(
+    rows: list[dict[str, str | int | float]],
+    ranking: FairnessRanking,
+    group_column: str | None = None,
+) -> pd.DataFrame:
+    dataframe = pd.DataFrame(rows)
+    if dataframe.empty:
+        return dataframe
+
+    ranking_values = dataframe[ranking.metric]
+    ascending = ranking.goal != "maximize"
+    if ranking.goal == "target":
+        ranking_values = (ranking_values - ranking.target).abs()
+
+    if group_column:
+        ranks = ranking_values.groupby(dataframe[group_column]).rank(
+            method="min", ascending=ascending
+        )
+        dataframe.insert(1, "Rank", ranks.astype(int))
+        return dataframe.sort_values([group_column, "Rank", "Model"])
+
+    ranks = ranking_values.rank(method="min", ascending=ascending)
+    dataframe.insert(0, "Rank", ranks.astype(int))
+    return dataframe.sort_values(["Rank", "Model"])
+
+
+def create_bias_type_scorecard(
+    ranked_dataframe: pd.DataFrame,
+    ranking: FairnessRanking,
+) -> pd.DataFrame:
+    bias_types = ranked_dataframe["Bias type"].drop_duplicates().tolist()
+    scores = ranked_dataframe.pivot(
+        index="Model", columns="Bias type", values=ranking.metric
+    ).reindex(columns=bias_types)
+    ranks = ranked_dataframe.pivot(
+        index="Model", columns="Bias type", values="Rank"
+    ).reindex(columns=bias_types)
+
+    scorecard = scores.map(lambda score: "—" if pd.isna(score) else f"{score:.2f}")
+    for bias_type in bias_types:
+        winners = ranks[bias_type] == 1
+        scorecard.loc[winners, bias_type] = "★ " + scorecard.loc[winners, bias_type]
+
+    scorecard.insert(0, "Wins", (ranks == 1).sum(axis=1))
+    return scorecard.reset_index().sort_values(["Wins", "Model"], ascending=[False, True])
+
+
+def _load_scores(path: Path, label: str, scores: dict[str, Any]) -> dict[str, float]:
+    loaded_scores = {}
+    for metric_name, metric_value in scores.items():
+        value = float(metric_value)
+        if not math.isfinite(value):
+            raise ValueError(f"{path}: {label} · {metric_name} must be finite")
+        loaded_scores[metric_name] = round(value, 2)
+    return loaded_scores
+
+
+def _load_ranking(path: Path, benchmark: dict[str, Any]) -> FairnessRanking:
+    ranking = benchmark["ranking"]
+    goal = ranking["goal"]
+    if goal not in {"maximize", "minimize", "target"}:
+        raise ValueError(f"{path}: unsupported ranking goal {goal}")
+    target = float(ranking["target"]) if goal == "target" else None
+    return FairnessRanking(metric=ranking["metric"], goal=goal, target=target)
+
+
+def _load_result(
+    path: Path,
+) -> tuple[str, list[tuple[str, FairnessRanking, dict, list[dict]]]]:
+    payload: dict[str, Any] = json.loads(path.read_text(encoding="utf-8"))
+    model_name = payload["model"]["name"]
+    loaded_benchmarks = []
+    benchmark_names = set()
+
+    for benchmark in payload["benchmarks"]:
+        benchmark_name = benchmark["name"]
+        if benchmark_name in benchmark_names:
+            raise ValueError(f"{path}: duplicate benchmark {benchmark_name}")
+        benchmark_names.add(benchmark_name)
+
+        ranking = _load_ranking(path, benchmark)
+        scores = _load_scores(path, benchmark_name, benchmark["scores"])
+        if ranking.metric not in scores:
+            raise ValueError(f"{path}: missing ranking metric {ranking.metric}")
+
+        overall_row = {"Model": model_name, **scores}
+        bias_type_rows = []
+        for bias_type in benchmark.get("bias_types", []):
+            bias_type_name = bias_type["name"]
+            bias_type_scores = _load_scores(path, bias_type_name, bias_type["scores"])
+            if ranking.metric not in bias_type_scores:
+                raise ValueError(f"{path}: {bias_type_name} missing {ranking.metric}")
+            bias_type_rows.append(
+                {
+                    "Bias type": bias_type_name,
+                    "Items": int(bias_type["items"]),
+                    "Model": model_name,
+                    **bias_type_scores,
+                }
+            )
+
+        loaded_benchmarks.append(
+            (benchmark_name, ranking, overall_row, bias_type_rows)
+        )
+
+    return model_name, loaded_benchmarks
+
+
+def load_fairness_benchmarks(
+    results_dir: str | Path = "eval-results/fairness",
+) -> dict[str, FairnessBenchmark]:
+    results = [_load_result(path) for path in sorted(Path(results_dir).glob("*.json"))]
+    model_counts = Counter(model_name for model_name, _ in results)
+    duplicate_models = sorted(model for model, count in model_counts.items() if count > 1)
+    if duplicate_models:
+        raise ValueError(f"Duplicate fairness results for: {', '.join(duplicate_models)}")
+
+    benchmarks = {}
+    for _, model_benchmarks in results:
+        for benchmark_name, ranking, overall_row, bias_type_rows in model_benchmarks:
+            benchmark = benchmarks.setdefault(
+                benchmark_name,
+                FairnessBenchmark(ranking=ranking, overall_rows=[], bias_type_rows=[]),
+            )
+            if benchmark.ranking != ranking:
+                raise ValueError(f"Inconsistent ranking for {benchmark_name}")
+            benchmark.overall_rows.append(overall_row)
+            benchmark.bias_type_rows.extend(bias_type_rows)
+
+    return benchmarks
+
+
+def render_fairness_tab() -> None:
+    benchmarks = load_fairness_benchmarks()
+    benchmark_names = list(dict.fromkeys([*FAIRNESS_BENCHMARK_METRICS, *benchmarks]))
+
+    with gr.Tab("⚖️ Fairness"):
+        gr.Markdown(
+            """
+        ## Ukrainian Fairness Leaderboard
+
+        Each benchmark has its own table. Metric arrows show whether higher values, zero, or 50 are preferred.
+        """
+        )
+        with gr.Tabs():
+            for benchmark_name in benchmark_names:
+                benchmark = benchmarks.get(benchmark_name)
+                metrics = FAIRNESS_BENCHMARK_METRICS.get(benchmark_name, ())
+                with gr.Tab(benchmark_name):
+                    if benchmark_name == "StereoSet-UK Eval":
+                        gr.Markdown(
+                            """
+                        **LMS ↑** measures preference for related completions. **SS → 50** measures stereotype preference, with 50 as the neutral point. **ICAT ↑** combines language-model quality and stereotype neutrality.
+                        """
+                        )
+                        if benchmark is not None:
+                            gr.Markdown(
+                                "Current results cover the provisional 949-item [StereoSet-UK Eval](https://huggingface.co/datasets/FairForget/StereoSet-UK-Eval) subset."
+                            )
+                    if benchmark is None:
+                        gr.Markdown("Results pending. Planned metrics appear below.")
+                        gr.Dataframe(
+                            value=pd.DataFrame(columns=["Model", *metrics]),
+                            label=benchmark_name,
+                            interactive=False,
+                            wrap=False,
+                        )
+                    elif benchmark.bias_type_rows:
+                        bias_type_dataframe = create_ranked_fairness_dataframe(
+                            benchmark.bias_type_rows,
+                            benchmark.ranking,
+                            "Bias type",
+                        )
+                        with gr.Tabs():
+                            with gr.Tab("Overall"):
+                                gr.Dataframe(
+                                    value=create_ranked_fairness_dataframe(
+                                        benchmark.overall_rows,
+                                        benchmark.ranking,
+                                    ),
+                                    label=f"{benchmark_name} overall",
+                                    interactive=False,
+                                    wrap=False,
+                                )
+                            with gr.Tab("By bias type"):
+                                gr.Markdown(
+                                    f"Each column is a bias type. ★ marks the best **{benchmark.ranking.metric}** score."
+                                )
+                                gr.Dataframe(
+                                    value=create_bias_type_scorecard(
+                                        bias_type_dataframe,
+                                        benchmark.ranking,
+                                    ),
+                                    label="Bias type comparison",
+                                    interactive=False,
+                                    wrap=False,
+                                )
+                    else:
+                        gr.Dataframe(
+                            value=create_ranked_fairness_dataframe(
+                                benchmark.overall_rows,
+                                benchmark.ranking,
+                            ),
+                            label=benchmark_name,
+                            interactive=False,
+                            wrap=False,
+                        )

--- a/leaderboard.py
+++ b/leaderboard.py
@@ -10,6 +10,8 @@ from typing import Dict, List, Any, Tuple, Optional
 from huggingface_hub import snapshot_download
 from pathlib import Path
 
+from fairness import render_fairness_tab
+
 # Define the key benchmarks to track from the JSON results file
 # Define the key benchmarks to track from the JSON results file
 MAIN_BENCHMARKS = {
@@ -539,6 +541,8 @@ def create_leaderboard_app() -> gr.Blocks:
                         value=False, label="Show Relative Scores (%)"
                     )
                     refresh_btn = gr.Button("🔄 Refresh Data")
+
+        render_fairness_tab()
 
         # Detailed Benchmarks Tab
         with gr.Tab("📈 Detailed Benchmarks"):

--- a/tests/test_fairness.py
+++ b/tests/test_fairness.py
@@ -1,0 +1,141 @@
+import json
+import tempfile
+import unittest
+from pathlib import Path
+
+from fairness import (
+    FAIRNESS_BENCHMARK_METRICS,
+    FairnessBenchmark,
+    FairnessRanking,
+    load_fairness_benchmarks,
+)
+
+
+def write_result(directory: Path, filename: str, model: str, benchmarks: list[dict]) -> None:
+    payload = {"model": {"name": model, "revision": "revision"}, "benchmarks": benchmarks}
+    (directory / filename).write_text(json.dumps(payload), encoding="utf-8")
+
+
+def stereoset_result(icat: float = 70.0) -> dict:
+    return {
+        "name": "StereoSet-UK Eval",
+        "ranking": {"metric": "ICAT ↑", "goal": "maximize"},
+        "scores": {"LMS ↑": 80.0, "SS → 50": 50.0, "ICAT ↑": icat},
+        "bias_types": [
+            {
+                "name": "Gender",
+                "items": 10,
+                "scores": {"LMS ↑": 60.0, "SS → 50": 40.0, "ICAT ↑": 55.0},
+            }
+        ],
+    }
+
+
+class FairnessResultsTests(unittest.TestCase):
+    def test_loads_overall_and_bias_type_rows(self):
+        with tempfile.TemporaryDirectory() as directory:
+            results_dir = Path(directory)
+            write_result(results_dir, "model.json", "example/model", [stereoset_result()])
+
+            benchmarks = load_fairness_benchmarks(results_dir)
+
+        self.assertEqual(
+            benchmarks,
+            {
+                "StereoSet-UK Eval": FairnessBenchmark(
+                    ranking=FairnessRanking(metric="ICAT ↑", goal="maximize"),
+                    overall_rows=[
+                        {
+                            "Model": "example/model",
+                            "LMS ↑": 80.0,
+                            "SS → 50": 50.0,
+                            "ICAT ↑": 70.0,
+                        }
+                    ],
+                    bias_type_rows=[
+                        {
+                            "Bias type": "Gender",
+                            "Items": 10,
+                            "Model": "example/model",
+                            "LMS ↑": 60.0,
+                            "SS → 50": 40.0,
+                            "ICAT ↑": 55.0,
+                        }
+                    ],
+                )
+            },
+        )
+
+    def test_loads_each_benchmark_without_display_code_changes(self):
+        bbq = {
+            "name": "BBQ-UK",
+            "ranking": {"metric": "Accuracy ↑", "goal": "maximize"},
+            "scores": {"Accuracy ↑": 81.456},
+        }
+        with tempfile.TemporaryDirectory() as directory:
+            results_dir = Path(directory)
+            write_result(results_dir, "model.json", "example/model", [bbq])
+
+            benchmarks = load_fairness_benchmarks(results_dir)
+
+        self.assertEqual(
+            benchmarks["BBQ-UK"].overall_rows,
+            [{"Model": "example/model", "Accuracy ↑": 81.46}],
+        )
+
+    def test_rejects_duplicate_model_results(self):
+        with tempfile.TemporaryDirectory() as directory:
+            results_dir = Path(directory)
+            write_result(results_dir, "first.json", "example/model", [stereoset_result()])
+            write_result(results_dir, "second.json", "example/model", [stereoset_result()])
+
+            with self.assertRaisesRegex(ValueError, "Duplicate fairness results"):
+                load_fairness_benchmarks(results_dir)
+
+    def test_rejects_duplicate_benchmarks(self):
+        with tempfile.TemporaryDirectory() as directory:
+            results_dir = Path(directory)
+            benchmark = stereoset_result()
+            write_result(results_dir, "model.json", "example/model", [benchmark, benchmark])
+
+            with self.assertRaisesRegex(ValueError, "duplicate benchmark"):
+                load_fairness_benchmarks(results_dir)
+
+    def test_rejects_missing_ranking_metric(self):
+        with tempfile.TemporaryDirectory() as directory:
+            results_dir = Path(directory)
+            benchmark = stereoset_result()
+            benchmark["ranking"]["metric"] = "Missing"
+            write_result(results_dir, "model.json", "example/model", [benchmark])
+
+            with self.assertRaisesRegex(ValueError, "missing ranking metric"):
+                load_fairness_benchmarks(results_dir)
+
+    def test_rejects_non_finite_scores(self):
+        with tempfile.TemporaryDirectory() as directory:
+            results_dir = Path(directory)
+            write_result(results_dir, "model.json", "example/model", [stereoset_result(float("nan"))])
+
+            with self.assertRaisesRegex(ValueError, "must be finite"):
+                load_fairness_benchmarks(results_dir)
+
+    def test_returns_no_benchmarks_when_no_results_exist(self):
+        with tempfile.TemporaryDirectory() as directory:
+            self.assertEqual(load_fairness_benchmarks(directory), {})
+
+    def test_benchmark_stubs_have_metric_headers(self):
+        self.assertEqual(
+            set(FAIRNESS_BENCHMARK_METRICS),
+            {
+                "StereoSet-UK Eval",
+                "WinoBias-UK",
+                "WinoGender-UK",
+                "BBQ-UK",
+                "CrowS-Pairs-UK",
+            },
+        )
+        self.assertTrue(all(FAIRNESS_BENCHMARK_METRICS.values()))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_leaderboard.py
+++ b/tests/test_leaderboard.py
@@ -1,0 +1,73 @@
+import unittest
+
+from fairness import (
+    FairnessRanking,
+    create_bias_type_scorecard,
+    create_ranked_fairness_dataframe,
+)
+
+
+class LeaderboardResultsTests(unittest.TestCase):
+    def test_ranks_models_within_each_bias_type(self):
+        rows = [
+            {"Bias type": "Gender", "Model": "model/a", "ICAT ↑": 50.0},
+            {"Bias type": "Gender", "Model": "model/b", "ICAT ↑": 60.0},
+            {"Bias type": "Religion", "Model": "model/a", "ICAT ↑": 70.0},
+            {"Bias type": "Religion", "Model": "model/b", "ICAT ↑": 65.0},
+        ]
+
+        dataframe = create_ranked_fairness_dataframe(
+            rows,
+            FairnessRanking(metric="ICAT ↑", goal="maximize"),
+            "Bias type",
+        )
+
+        self.assertEqual(
+            dataframe[["Bias type", "Rank", "Model"]].to_dict("records"),
+            [
+                {"Bias type": "Gender", "Rank": 1, "Model": "model/b"},
+                {"Bias type": "Gender", "Rank": 2, "Model": "model/a"},
+                {"Bias type": "Religion", "Rank": 1, "Model": "model/a"},
+                {"Bias type": "Religion", "Rank": 2, "Model": "model/b"},
+            ],
+        )
+
+        scorecard = create_bias_type_scorecard(
+            dataframe,
+            FairnessRanking(metric="ICAT ↑", goal="maximize"),
+        )
+        self.assertEqual(
+            scorecard.to_dict("records"),
+            [
+                {
+                    "Model": "model/a",
+                    "Wins": 1,
+                    "Gender": "50.00",
+                    "Religion": "★ 70.00",
+                },
+                {
+                    "Model": "model/b",
+                    "Wins": 1,
+                    "Gender": "★ 60.00",
+                    "Religion": "65.00",
+                },
+            ],
+        )
+
+    def test_ranks_target_metrics_by_distance(self):
+        rows = [
+            {"Model": "model/a", "Stereotype score → 50": 60.0},
+            {"Model": "model/b", "Stereotype score → 50": 52.0},
+        ]
+
+        dataframe = create_ranked_fairness_dataframe(
+            rows,
+            FairnessRanking(
+                metric="Stereotype score → 50", goal="target", target=50.0
+            ),
+        )
+
+        self.assertEqual(dataframe["Model"].tolist(), ["model/b", "model/a"])
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- add a dedicated Fairness area with separate benchmark tabs
- rank models overall and independently within each available bias type
- show a model-by-bias matrix with bias types as columns, models as rows, and winning scores marked with ★
- load fairness JSON from the separate leaderboard results dataset under `eval-results/fairness`
- show metric stubs for WinoBias, WinoGender, BBQ, and CrowS-Pairs until their results arrive
- keep the existing leaderboard implementation unchanged apart from importing and rendering the fairness tab
- keep evaluation result JSON out of this code pull request

## Verification

- 10 unit tests pass
- Ruff passes for the new fairness code and tests
- Python compilation passes
- Gradio 6.2.0 interface construction passes
- the rendered StereoSet view shows all four bias types as columns and their ICAT-based winners

StereoSet ranks by ICAT. LMS and ICAT are higher-is-better; StereoSet SS and CrowS-Pairs stereotype score target 50; gap and BBQ bias metrics target zero.

## Fairness tab is separated from other results
<img width="1600" height="900" alt="Зображення Codex 22 серп  2026 р , 22_01_12" src="https://github.com/user-attachments/assets/21736e84-fdb9-4c2e-8f3f-cf81040499e1" />
