### PR TITLE
Show StereoSet-UK and WinoBias-UK fairness results

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ The data comes from evaluation results [lang-uk/ukrainian-llm-leaderboard-result
 
 ## 📏 What does it measure?
 The leaderboard evaluates models on a variety of benchmarks covering different NLP tasks in Ukrainian, including:
-- ⚖️ **Fairness**: StereoSet-UK Eval, with WinoBias, WinoGender, BBQ, and CrowS-Pairs planned
+- ⚖️ **Fairness**: StereoSet-UK Eval and WinoBias-UK Natural, with WinoGender, BBQ, and CrowS-Pairs planned
 - 🌐 **Machine Translation**: FLORES-200 (en-uk, uk-en), LongFLORES (en-uk, uk-en), WMT-22 (en-uk, uk-en)
 - 📌 **Summarization**: XLSUM (uk)
 - 🔎 **In-Context Question Answering**: Belebele (uk), SQuAD (uk)
@@ -53,7 +53,7 @@ If you want to leave a feedback or suggest a new feature, please open an issue o
 ### How to Use
 
 - **Main Leaderboard**: View performance on core benchmarks
-- **Fairness**: View bias and fairness metrics. Current StereoSet-UK Eval results cover a provisional 949-item subset.
+- **Fairness**: View bias and fairness metrics. StereoSet-UK Eval results cover a provisional 949-item subset. WinoBias-UK Natural results cover a preliminary 279-item, 1,674-row validation Type 1 release.
 - **Detailed Benchmarks**: Explore performance on specific benchmark categories
 - **Model Comparison**: Compare multiple models with radar charts
 - **Visualizations**: Generate bar charts for specific metrics

--- a/fairness.py
+++ b/fairness.py
@@ -10,11 +10,14 @@ import pandas as pd
 
 FAIRNESS_BENCHMARK_METRICS = {
     "StereoSet-UK Eval": ("LMS ↑", "SS → 50", "ICAT ↑"),
-    "WinoBias-UK": (
-        "Type 1 F1 ↑",
-        "Type 1 pro/anti gap → 0",
-        "Type 2 F1 ↑",
-        "Type 2 pro/anti gap → 0",
+    "WinoBias-UK Natural": (
+        "Worst-group accuracy ↑",
+        "Primary accuracy ↑",
+        "Pro/anti gap → 0",
+        "Pair consistency ↑",
+        "Agreement control ↑",
+        "Cross control ↑",
+        "Tie rate → 0",
     ),
     "WinoGender-UK": (
         "Accuracy ↑",
@@ -27,6 +30,20 @@ FAIRNESS_BENCHMARK_METRICS = {
         "Disambiguated bias → 0",
     ),
     "CrowS-Pairs-UK": ("Stereotype score → 50",),
+}
+
+FAIRNESS_BENCHMARK_DESCRIPTIONS = {
+    "StereoSet-UK Eval": """
+    **LMS ↑** measures preference for related completions. **SS → 50** measures stereotype preference, with 50 as the neutral point. **ICAT ↑** combines language-model quality and stereotype neutrality.
+    """,
+    "WinoBias-UK Natural": """
+    **Worst-group accuracy ↑** is the lower of pro- and anti-stereotypical primary accuracy. **Pro/anti gap → 0** measures the absolute difference between them. Agreement and cross controls measure whether the model follows Ukrainian grammatical gender cues.
+    """,
+}
+
+FAIRNESS_BENCHMARK_RELEASE_NOTES = {
+    "StereoSet-UK Eval": "Current results cover the provisional 949-item [StereoSet-UK Eval](https://huggingface.co/datasets/FairForget/StereoSet-UK-Eval) subset.",
+    "WinoBias-UK Natural": "Current results cover the preliminary 279-item, 1,674-row validation Type 1 release of [WinoBias-UK Natural](https://huggingface.co/datasets/FairForget/WinoBias-UK-Natural).",
 }
 
 
@@ -193,16 +210,15 @@ def render_fairness_tab() -> None:
                 benchmark = benchmarks.get(benchmark_name)
                 metrics = FAIRNESS_BENCHMARK_METRICS.get(benchmark_name, ())
                 with gr.Tab(benchmark_name):
-                    if benchmark_name == "StereoSet-UK Eval":
-                        gr.Markdown(
-                            """
-                        **LMS ↑** measures preference for related completions. **SS → 50** measures stereotype preference, with 50 as the neutral point. **ICAT ↑** combines language-model quality and stereotype neutrality.
-                        """
+                    description = FAIRNESS_BENCHMARK_DESCRIPTIONS.get(benchmark_name)
+                    if description:
+                        gr.Markdown(description)
+                    if benchmark is not None:
+                        release_note = FAIRNESS_BENCHMARK_RELEASE_NOTES.get(
+                            benchmark_name
                         )
-                        if benchmark is not None:
-                            gr.Markdown(
-                                "Current results cover the provisional 949-item [StereoSet-UK Eval](https://huggingface.co/datasets/FairForget/StereoSet-UK-Eval) subset."
-                            )
+                        if release_note:
+                            gr.Markdown(release_note)
                     if benchmark is None:
                         gr.Markdown("Results pending. Planned metrics appear below.")
                         gr.Dataframe(

--- a/tests/test_fairness.py
+++ b/tests/test_fairness.py
@@ -4,7 +4,9 @@ import unittest
 from pathlib import Path
 
 from fairness import (
+    FAIRNESS_BENCHMARK_DESCRIPTIONS,
     FAIRNESS_BENCHMARK_METRICS,
+    FAIRNESS_BENCHMARK_RELEASE_NOTES,
     FairnessBenchmark,
     FairnessRanking,
     load_fairness_benchmarks,
@@ -28,6 +30,22 @@ def stereoset_result(icat: float = 70.0) -> dict:
                 "scores": {"LMS ↑": 60.0, "SS → 50": 40.0, "ICAT ↑": 55.0},
             }
         ],
+    }
+
+
+def winobias_result(worst_group_accuracy: float = 72.0) -> dict:
+    return {
+        "name": "WinoBias-UK Natural",
+        "ranking": {"metric": "Worst-group accuracy ↑", "goal": "maximize"},
+        "scores": {
+            "Worst-group accuracy ↑": worst_group_accuracy,
+            "Primary accuracy ↑": 78.0,
+            "Pro/anti gap → 0": 12.0,
+            "Pair consistency ↑": 68.0,
+            "Agreement control ↑": 99.0,
+            "Cross control ↑": 91.0,
+            "Tie rate → 0": 0.0,
+        },
     }
 
 
@@ -83,6 +101,25 @@ class FairnessResultsTests(unittest.TestCase):
             [{"Model": "example/model", "Accuracy ↑": 81.46}],
         )
 
+    def test_loads_winobias_natural_metrics(self):
+        with tempfile.TemporaryDirectory() as directory:
+            results_dir = Path(directory)
+            write_result(
+                results_dir,
+                "model.json",
+                "example/model",
+                [stereoset_result(), winobias_result()],
+            )
+
+            benchmarks = load_fairness_benchmarks(results_dir)
+
+        winobias = benchmarks["WinoBias-UK Natural"]
+        self.assertEqual(
+            winobias.ranking,
+            FairnessRanking(metric="Worst-group accuracy ↑", goal="maximize"),
+        )
+        self.assertEqual(winobias.overall_rows[0]["Pro/anti gap → 0"], 12.0)
+
     def test_rejects_duplicate_model_results(self):
         with tempfile.TemporaryDirectory() as directory:
             results_dir = Path(directory)
@@ -128,13 +165,21 @@ class FairnessResultsTests(unittest.TestCase):
             set(FAIRNESS_BENCHMARK_METRICS),
             {
                 "StereoSet-UK Eval",
-                "WinoBias-UK",
+                "WinoBias-UK Natural",
                 "WinoGender-UK",
                 "BBQ-UK",
                 "CrowS-Pairs-UK",
             },
         )
         self.assertTrue(all(FAIRNESS_BENCHMARK_METRICS.values()))
+        self.assertLessEqual(
+            set(FAIRNESS_BENCHMARK_DESCRIPTIONS),
+            set(FAIRNESS_BENCHMARK_METRICS),
+        )
+        self.assertLessEqual(
+            set(FAIRNESS_BENCHMARK_RELEASE_NOTES),
+            set(FAIRNESS_BENCHMARK_METRICS),
+        )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

- add WinoBias-UK Natural to the existing fairness benchmark tabs
- rank WinoBias models by worst-group primary accuracy
- show primary accuracy, the absolute pro/anti gap, pair consistency, grammatical agreement controls, cross controls, and tie rate
- retain StereoSet overall ICAT ranking and its model-by-bias-type comparison
- label the evaluated releases as provisional StereoSet (949 items) and preliminary WinoBias validation Type 1 (279 items / 1,674 rows)
- keep all model scores in the separate Hugging Face results dataset

## Data

The tab reads per-model JSON files from `eval-results/fairness`, downloaded from [`lang-uk/ukrainian-llm-leaderboard-results`](https://huggingface.co/datasets/lang-uk/ukrainian-llm-leaderboard-results). Scores are intentionally excluded from this code pull request.

Results contribution: [Hugging Face PR #7](https://huggingface.co/datasets/lang-uk/ukrainian-llm-leaderboard-results/discussions/7)

Evaluation datasets:

- [FairForget/StereoSet-UK-Eval](https://huggingface.co/datasets/FairForget/StereoSet-UK-Eval)
- [FairForget/WinoBias-UK-Natural](https://huggingface.co/datasets/FairForget/WinoBias-UK-Natural)

## Verification

- 11 unit tests pass
- Ruff passes for the fairness code and tests
- the local Gradio view loads nine models for each benchmark
- StereoSet renders four bias-type columns
- WinoBias renders all seven metrics and ranks nine models by worst-group accuracy

## Deployment note

The Hugging Face sync workflow is currently disabled after repository inactivity. It will need to be re-enabled or run manually after merge.