### PR TITLE
Add WinoBias-UK and clarify fairness benchmark metrics

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 .gradio
+__pycache__/
 
 eval-results

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ The data comes from evaluation results [lang-uk/ukrainian-llm-leaderboard-result
 
 ## 📏 What does it measure?
 The leaderboard evaluates models on a variety of benchmarks covering different NLP tasks in Ukrainian, including:
-- ⚖️ **Fairness**: StereoSet-UK Eval, with WinoBias, WinoGender, BBQ, and CrowS-Pairs planned
+- ⚖️ **Fairness**: StereoSet-UK Eval and WinoBias-UK Natural, with WinoGender, BBQ, and CrowS-Pairs planned
 - 🌐 **Machine Translation**: FLORES-200 (en-uk, uk-en), LongFLORES (en-uk, uk-en), WMT-22 (en-uk, uk-en)
 - 📌 **Summarization**: XLSUM (uk)
 - 🔎 **In-Context Question Answering**: Belebele (uk), SQuAD (uk)
@@ -53,7 +53,7 @@ If you want to leave a feedback or suggest a new feature, please open an issue o
 ### How to Use
 
 - **Main Leaderboard**: View performance on core benchmarks
-- **Fairness**: View bias and fairness metrics. Current StereoSet-UK Eval results cover a provisional 949-item subset.
+- **Fairness**: View bias and fairness metrics. StereoSet-UK Eval results cover a provisional 949-item subset. WinoBias-UK Natural results cover a preliminary 279-item, 1,674-row validation Type 1 release.
 - **Detailed Benchmarks**: Explore performance on specific benchmark categories
 - **Model Comparison**: Compare multiple models with radar charts
 - **Visualizations**: Generate bar charts for specific metrics

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ The data comes from evaluation results [lang-uk/ukrainian-llm-leaderboard-result
 
 ## 📏 What does it measure?
 The leaderboard evaluates models on a variety of benchmarks covering different NLP tasks in Ukrainian, including:
-- ⚖️ **Fairness**: StereoSet-UK Eval and WinoBias-UK Natural, with WinoPron-UK and BBQ-UK result integration in progress
+- ⚖️ **Fairness**: StereoSet-UK Eval, WinoBias-UK Natural, and preliminary BBQ-UK results, with WinoPron-UK integration in progress
 - 🌐 **Machine Translation**: FLORES-200 (en-uk, uk-en), LongFLORES (en-uk, uk-en), WMT-22 (en-uk, uk-en)
 - 📌 **Summarization**: XLSUM (uk)
 - 🔎 **In-Context Question Answering**: Belebele (uk), SQuAD (uk)
@@ -50,7 +50,7 @@ If you want to leave a feedback or suggest a new feature, please open an issue o
 - **FLORES benchmarks**: Only English↔Ukrainian (en-uk, uk-en) translation pairs are displayed
 - **MMLU**: Only the aggregate score is shown (no subcategories)
 - **Fairness scope**: These benchmarks measure social bias expressed through model preferences, coreference decisions, and question answering. They do not evaluate whether a model can detect biased text or provide a general ethical-alignment score. [UAlign](https://aclanthology.org/2025.unlp-1.4/) covers the broader Ukrainian alignment setting.
-- **Fairness status**: StereoSet-UK Eval uses a provisional 949-item subset, and WinoBias-UK Natural uses a preliminary 279-item, 1,674-row release. WinoPron-UK and BBQ-UK results are pending publication.
+- **Fairness status**: StereoSet-UK Eval uses a provisional 949-item subset, WinoBias-UK Natural uses a preliminary 279-item, 1,674-row release, and BBQ-UK currently reports seven evaluated models. WinoPron-UK results are pending publication.
 
 ### How to Use
 

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ The data comes from evaluation results [lang-uk/ukrainian-llm-leaderboard-result
 
 ## 📏 What does it measure?
 The leaderboard evaluates models on a variety of benchmarks covering different NLP tasks in Ukrainian, including:
-- ⚖️ **Fairness**: StereoSet-UK Eval, WinoBias-UK Natural, and preliminary BBQ-UK results, with WinoPron-UK integration in progress
+- ⚖️ **Fairness**: StereoSet-UK Eval, WinoBias-UK Natural, BBQ-UK, and WinoPron-UK
 - 🌐 **Machine Translation**: FLORES-200 (en-uk, uk-en), LongFLORES (en-uk, uk-en), WMT-22 (en-uk, uk-en)
 - 📌 **Summarization**: XLSUM (uk)
 - 🔎 **In-Context Question Answering**: Belebele (uk), SQuAD (uk)
@@ -50,7 +50,6 @@ If you want to leave a feedback or suggest a new feature, please open an issue o
 - **FLORES benchmarks**: Only English↔Ukrainian (en-uk, uk-en) translation pairs are displayed
 - **MMLU**: Only the aggregate score is shown (no subcategories)
 - **Fairness scope**: These benchmarks measure social bias expressed through model preferences, coreference decisions, and question answering. They do not evaluate whether a model can detect biased text or provide a general ethical-alignment score. [UAlign](https://aclanthology.org/2025.unlp-1.4/) covers the broader Ukrainian alignment setting.
-- **Fairness status**: StereoSet-UK Eval uses a provisional 949-item subset, WinoBias-UK Natural uses a preliminary 279-item, 1,674-row release, and BBQ-UK currently reports seven evaluated models. WinoPron-UK results are pending publication.
 
 ### How to Use
 

--- a/README.md
+++ b/README.md
@@ -50,8 +50,7 @@ If you want to leave a feedback or suggest a new feature, please open an issue o
 - **FLORES benchmarks**: Only English↔Ukrainian (en-uk, uk-en) translation pairs are displayed
 - **MMLU**: Only the aggregate score is shown (no subcategories)
 - **Fairness scope**: These benchmarks measure social bias expressed through model preferences, coreference decisions, and question answering. They do not evaluate whether a model can detect biased text or provide a general ethical-alignment score. [UAlign](https://aclanthology.org/2025.unlp-1.4/) covers the broader Ukrainian alignment setting.
-- **Fairness data**: Public results contain aggregate per-model metrics and available bias-type summaries. Per-item model predictions and likelihood traces are not currently published.
-- **Fairness status**: StereoSet-UK Eval uses a provisional 949-item subset, and WinoBias-UK Natural uses a preliminary 279-item, 1,674-row validation Type 1 release. WinoPron-UK and BBQ-UK results are pending publication.
+- **Fairness status**: StereoSet-UK Eval uses a provisional 949-item subset, and WinoBias-UK Natural uses a preliminary 279-item, 1,674-row release. WinoPron-UK and BBQ-UK results are pending publication.
 
 ### How to Use
 

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ The data comes from evaluation results [lang-uk/ukrainian-llm-leaderboard-result
 
 ## 📏 What does it measure?
 The leaderboard evaluates models on a variety of benchmarks covering different NLP tasks in Ukrainian, including:
-- ⚖️ **Fairness**: StereoSet-UK Eval and WinoBias-UK Natural, with WinoGender, BBQ, and CrowS-Pairs planned
+- ⚖️ **Fairness**: StereoSet-UK Eval and WinoBias-UK Natural, with WinoPron-UK and BBQ-UK result integration in progress
 - 🌐 **Machine Translation**: FLORES-200 (en-uk, uk-en), LongFLORES (en-uk, uk-en), WMT-22 (en-uk, uk-en)
 - 📌 **Summarization**: XLSUM (uk)
 - 🔎 **In-Context Question Answering**: Belebele (uk), SQuAD (uk)
@@ -49,11 +49,14 @@ If you want to leave a feedback or suggest a new feature, please open an issue o
 
 - **FLORES benchmarks**: Only English↔Ukrainian (en-uk, uk-en) translation pairs are displayed
 - **MMLU**: Only the aggregate score is shown (no subcategories)
+- **Fairness scope**: These benchmarks measure social bias expressed through model preferences, coreference decisions, and question answering. They do not evaluate whether a model can detect biased text or provide a general ethical-alignment score. [UAlign](https://aclanthology.org/2025.unlp-1.4/) covers the broader Ukrainian alignment setting.
+- **Fairness data**: Public results contain aggregate per-model metrics and available bias-type summaries. Per-item model predictions and likelihood traces are not currently published.
+- **Fairness status**: StereoSet-UK Eval uses a provisional 949-item subset, and WinoBias-UK Natural uses a preliminary 279-item, 1,674-row validation Type 1 release. WinoPron-UK and BBQ-UK results are pending publication.
 
 ### How to Use
 
 - **Main Leaderboard**: View performance on core benchmarks
-- **Fairness**: View bias and fairness metrics. StereoSet-UK Eval results cover a provisional 949-item subset. WinoBias-UK Natural results cover a preliminary 279-item, 1,674-row validation Type 1 release.
+- **Fairness**: Compare social-bias metrics by benchmark and, where available, by bias type. Each tab explains whether higher, lower, zero, or 50 is preferred for every displayed metric.
 - **Detailed Benchmarks**: Explore performance on specific benchmark categories
 - **Model Comparison**: Compare multiple models with radar charts
 - **Visualizations**: Generate bar charts for specific metrics

--- a/fairness.py
+++ b/fairness.py
@@ -10,11 +10,14 @@ import pandas as pd
 
 FAIRNESS_BENCHMARK_METRICS = {
     "StereoSet-UK Eval": ("LMS ↑", "SS → 50", "ICAT ↑"),
-    "WinoBias-UK": (
-        "Type 1 F1 ↑",
-        "Type 1 pro/anti gap → 0",
-        "Type 2 F1 ↑",
-        "Type 2 pro/anti gap → 0",
+    "WinoBias-UK Natural": (
+        "Worst-group accuracy ↑",
+        "Primary accuracy ↑",
+        "Pro/anti gap → 0",
+        "Pair consistency ↑",
+        "Agreement control ↑",
+        "Cross control ↑",
+        "Tie rate → 0",
     ),
     "WinoGender-UK": (
         "Accuracy ↑",
@@ -27,6 +30,20 @@ FAIRNESS_BENCHMARK_METRICS = {
         "Disambiguated bias → 0",
     ),
     "CrowS-Pairs-UK": ("Stereotype score → 50",),
+}
+
+FAIRNESS_BENCHMARK_DESCRIPTIONS = {
+    "StereoSet-UK Eval": """
+    **LMS ↑** measures preference for related completions. **SS → 50** measures stereotype preference, with 50 as the neutral point. **ICAT ↑** combines language-model quality and stereotype neutrality.
+    """,
+    "WinoBias-UK Natural": """
+    **Worst-group accuracy ↑** is the lower of pro- and anti-stereotypical primary accuracy. **Pro/anti gap → 0** measures the absolute difference between them. Agreement and cross controls measure whether the model follows Ukrainian grammatical gender cues.
+    """,
+}
+
+FAIRNESS_BENCHMARK_RELEASE_NOTES = {
+    "StereoSet-UK Eval": "Current results cover the provisional 949-item [StereoSet-UK Eval](https://huggingface.co/datasets/FairForget/StereoSet-UK-Eval) subset.",
+    "WinoBias-UK Natural": "Current results cover the preliminary 279-item, 1,674-row validation Type 1 release of [WinoBias-UK Natural](https://huggingface.co/datasets/FairForget/WinoBias-UK-Natural).",
 }
 
 
@@ -193,16 +210,15 @@ def render_fairness_tab() -> None:
                 benchmark = benchmarks.get(benchmark_name)
                 metrics = FAIRNESS_BENCHMARK_METRICS.get(benchmark_name, ())
                 with gr.Tab(benchmark_name):
-                    if benchmark_name == "StereoSet-UK Eval":
-                        gr.Markdown(
-                            """
-                        **LMS ↑** measures preference for related completions. **SS → 50** measures stereotype preference, with 50 as the neutral point. **ICAT ↑** combines language-model quality and stereotype neutrality.
-                        """
+                    description = FAIRNESS_BENCHMARK_DESCRIPTIONS.get(benchmark_name)
+                    if description:
+                        gr.Markdown(description)
+                    if benchmark is not None:
+                        release_note = FAIRNESS_BENCHMARK_RELEASE_NOTES.get(
+                            benchmark_name
                         )
-                        if benchmark is not None:
-                            gr.Markdown(
-                                "Current results cover the provisional 949-item [StereoSet-UK Eval](https://huggingface.co/datasets/FairForget/StereoSet-UK-Eval) subset."
-                            )
+                        if release_note:
+                            gr.Markdown(release_note)
                     if benchmark is None:
                         gr.Markdown("Results pending. Planned metrics appear below.")
                         gr.Dataframe(

--- a/fairness.py
+++ b/fairness.py
@@ -65,10 +65,10 @@ FAIRNESS_BENCHMARK_DESCRIPTIONS = {
 }
 
 FAIRNESS_BENCHMARK_RELEASE_NOTES = {
-    "StereoSet-UK Eval": "Current results cover the provisional 949-item [StereoSet-UK Eval](https://huggingface.co/datasets/FairForget/StereoSet-UK-Eval) subset.",
-    "WinoBias-UK Natural": "Current results cover the preliminary 279-item, 1,674-row release of [WinoBias-UK Natural](https://huggingface.co/datasets/FairForget/WinoBias-UK-Natural).",
-    "WinoPron-UK": "[WinoPron-UK](https://huggingface.co/datasets/FairForget/WinoPron-UK) covers all 180 complementary source pairs. Leaderboard results are pending publication.",
-    "BBQ-UK": "[BBQ-UK](https://huggingface.co/datasets/FairForget/BBQ-UK) contains 29,246 ambiguous/disambiguated context pairs and 58,492 task rows. Current preliminary results cover seven models; models without results are not shown.",
+    "StereoSet-UK Eval": "Dataset: [StereoSet-UK Eval](https://huggingface.co/datasets/FairForget/StereoSet-UK-Eval)",
+    "WinoBias-UK Natural": "Dataset: [WinoBias-UK Natural](https://huggingface.co/datasets/FairForget/WinoBias-UK-Natural)",
+    "WinoPron-UK": "Dataset: [WinoPron-UK](https://huggingface.co/datasets/FairForget/WinoPron-UK)",
+    "BBQ-UK": "Dataset: [BBQ-UK](https://huggingface.co/datasets/FairForget/BBQ-UK)",
 }
 
 
@@ -230,8 +230,6 @@ def render_fairness_tab() -> None:
         This section measures social bias expressed through model preferences, coreference decisions, and question answering. It does not evaluate whether a model can detect biased text or provide a general ethical-alignment score; [UAlign](https://aclanthology.org/2025.unlp-1.4/) covers the broader Ukrainian alignment setting.
 
         Each benchmark has its own table. Metric arrows show whether higher values, zero, or 50 are preferred. Rankings use the benchmark's primary metric, while the remaining metrics provide necessary context.
-
-        Results from provisional or preliminary dataset releases should be interpreted accordingly.
         """
         )
         with gr.Tabs():

--- a/fairness.py
+++ b/fairness.py
@@ -68,7 +68,7 @@ FAIRNESS_BENCHMARK_RELEASE_NOTES = {
     "StereoSet-UK Eval": "Current results cover the provisional 949-item [StereoSet-UK Eval](https://huggingface.co/datasets/FairForget/StereoSet-UK-Eval) subset.",
     "WinoBias-UK Natural": "Current results cover the preliminary 279-item, 1,674-row release of [WinoBias-UK Natural](https://huggingface.co/datasets/FairForget/WinoBias-UK-Natural).",
     "WinoPron-UK": "[WinoPron-UK](https://huggingface.co/datasets/FairForget/WinoPron-UK) covers all 180 complementary source pairs. Leaderboard results are pending publication.",
-    "BBQ-UK": "[BBQ-UK](https://huggingface.co/datasets/FairForget/BBQ-UK) contains 29,246 ambiguous/disambiguated context pairs and 58,492 task rows. Leaderboard results are pending publication.",
+    "BBQ-UK": "[BBQ-UK](https://huggingface.co/datasets/FairForget/BBQ-UK) contains 29,246 ambiguous/disambiguated context pairs and 58,492 task rows. Current preliminary results cover seven models; models without results are not shown.",
 }
 
 

--- a/fairness.py
+++ b/fairness.py
@@ -19,9 +19,13 @@ FAIRNESS_BENCHMARK_METRICS = {
         "Cross control ↑",
         "Tie rate → 0",
     ),
-    "WinoGender-UK": (
-        "Accuracy ↑",
+    "WinoPron-UK": (
+        "Double accuracy ↑",
+        "Single accuracy ↑",
         "Gender accuracy gap → 0",
+        "Gender-form consistency ↑",
+        "Option-order consistency ↑",
+        "Tie rate → 0",
     ),
     "BBQ-UK": (
         "Ambiguous accuracy ↑",
@@ -29,21 +33,42 @@ FAIRNESS_BENCHMARK_METRICS = {
         "Ambiguous bias → 0",
         "Disambiguated bias → 0",
     ),
-    "CrowS-Pairs-UK": ("Stereotype score → 50",),
 }
 
 FAIRNESS_BENCHMARK_DESCRIPTIONS = {
     "StereoSet-UK Eval": """
-    **LMS ↑** measures preference for related completions. **SS → 50** measures stereotype preference, with 50 as the neutral point. **ICAT ↑** combines language-model quality and stereotype neutrality.
+    - **LMS ↑:** related completions should score above unrelated ones; higher is better.
+    - **SS → 50:** 50 is neutral. Above 50 indicates stereotypical preference, while below 50 indicates anti-stereotypical preference; a larger distance from 50 means stronger skew.
+    - **ICAT ↑:** combines LMS with stereotype neutrality; higher is better, while a low score reflects weak language modelling, stronger skew, or both.
     """,
     "WinoBias-UK Natural": """
-    **Worst-group accuracy ↑** is the lower of pro- and anti-stereotypical primary accuracy. **Pro/anti gap → 0** measures the absolute difference between them. Agreement and cross controls measure whether the model follows Ukrainian grammatical gender cues.
+    - **Worst-group accuracy ↑:** lower of pro- and anti-stereotypical accuracy; higher means the model performs well on both groups.
+    - **Primary accuracy ↑:** mean pro/anti coreference accuracy; higher is better.
+    - **Pro/anti gap → 0:** absolute accuracy difference; lower means more balanced behaviour.
+    - **Pair consistency ↑:** share of matched pro/anti pairs answered correctly in both forms; higher is better.
+    - **Agreement control ↑ / Cross control ↑:** accuracy when Ukrainian grammatical gender identifies either referent; higher means the model follows the grammatical cue more reliably.
+    - **Tie rate → 0:** share of equal-scoring choices; lower is better.
+    """,
+    "WinoPron-UK": """
+    - **Double accuracy ↑:** coreference accuracy when an occupation and another participant are present; higher is better.
+    - **Single accuracy ↑:** accuracy on matched single-referent controls; higher is better.
+    - **Gender accuracy gap → 0:** absolute female/male accuracy difference; lower means more balanced performance.
+    - **Gender-form consistency ↑:** share of matched gender forms resolved consistently; higher is better.
+    - **Option-order consistency ↑:** share unchanged when answer order is reversed; higher is better.
+    - **Tie rate → 0:** share of equal-scoring choices; lower is better.
+    """,
+    "BBQ-UK": """
+    - **Ambiguous accuracy ↑:** correct selection of the unknown answer when context is insufficient; higher is better.
+    - **Disambiguated accuracy ↑:** correct use of explicit contextual evidence; higher is better.
+    - **Ambiguous bias → 0 / Disambiguated bias → 0:** mean absolute bias across categories; lower means weaker group preference, while higher means stronger skew. Accuracy should be considered alongside both bias scores.
     """,
 }
 
 FAIRNESS_BENCHMARK_RELEASE_NOTES = {
     "StereoSet-UK Eval": "Current results cover the provisional 949-item [StereoSet-UK Eval](https://huggingface.co/datasets/FairForget/StereoSet-UK-Eval) subset.",
     "WinoBias-UK Natural": "Current results cover the preliminary 279-item, 1,674-row validation Type 1 release of [WinoBias-UK Natural](https://huggingface.co/datasets/FairForget/WinoBias-UK-Natural).",
+    "WinoPron-UK": "[WinoPron-UK](https://huggingface.co/datasets/FairForget/WinoPron-UK) covers all 180 complementary source pairs. Leaderboard results are pending publication.",
+    "BBQ-UK": "[BBQ-UK](https://huggingface.co/datasets/FairForget/BBQ-UK) contains 29,246 ambiguous/disambiguated context pairs and 58,492 task rows. Leaderboard results are pending publication.",
 }
 
 
@@ -202,7 +227,11 @@ def render_fairness_tab() -> None:
             """
         ## Ukrainian Fairness Leaderboard
 
-        Each benchmark has its own table. Metric arrows show whether higher values, zero, or 50 are preferred.
+        This section measures social bias expressed through model preferences, coreference decisions, and question answering. It does not evaluate whether a model can detect biased text or provide a general ethical-alignment score; [UAlign](https://aclanthology.org/2025.unlp-1.4/) covers the broader Ukrainian alignment setting.
+
+        Each benchmark has its own table. Metric arrows show whether higher values, zero, or 50 are preferred. Rankings use the benchmark's primary metric, while the remaining metrics provide necessary context.
+
+        The public results contain aggregate metrics and available bias-type summaries. Per-item model predictions and likelihood traces are not currently published. Results from provisional or preliminary dataset releases should be interpreted accordingly.
         """
         )
         with gr.Tabs():
@@ -213,12 +242,9 @@ def render_fairness_tab() -> None:
                     description = FAIRNESS_BENCHMARK_DESCRIPTIONS.get(benchmark_name)
                     if description:
                         gr.Markdown(description)
-                    if benchmark is not None:
-                        release_note = FAIRNESS_BENCHMARK_RELEASE_NOTES.get(
-                            benchmark_name
-                        )
-                        if release_note:
-                            gr.Markdown(release_note)
+                    release_note = FAIRNESS_BENCHMARK_RELEASE_NOTES.get(benchmark_name)
+                    if release_note:
+                        gr.Markdown(release_note)
                     if benchmark is None:
                         gr.Markdown("Results pending. Planned metrics appear below.")
                         gr.Dataframe(

--- a/fairness.py
+++ b/fairness.py
@@ -66,7 +66,7 @@ FAIRNESS_BENCHMARK_DESCRIPTIONS = {
 
 FAIRNESS_BENCHMARK_RELEASE_NOTES = {
     "StereoSet-UK Eval": "Current results cover the provisional 949-item [StereoSet-UK Eval](https://huggingface.co/datasets/FairForget/StereoSet-UK-Eval) subset.",
-    "WinoBias-UK Natural": "Current results cover the preliminary 279-item, 1,674-row validation Type 1 release of [WinoBias-UK Natural](https://huggingface.co/datasets/FairForget/WinoBias-UK-Natural).",
+    "WinoBias-UK Natural": "Current results cover the preliminary 279-item, 1,674-row release of [WinoBias-UK Natural](https://huggingface.co/datasets/FairForget/WinoBias-UK-Natural).",
     "WinoPron-UK": "[WinoPron-UK](https://huggingface.co/datasets/FairForget/WinoPron-UK) covers all 180 complementary source pairs. Leaderboard results are pending publication.",
     "BBQ-UK": "[BBQ-UK](https://huggingface.co/datasets/FairForget/BBQ-UK) contains 29,246 ambiguous/disambiguated context pairs and 58,492 task rows. Leaderboard results are pending publication.",
 }
@@ -231,7 +231,7 @@ def render_fairness_tab() -> None:
 
         Each benchmark has its own table. Metric arrows show whether higher values, zero, or 50 are preferred. Rankings use the benchmark's primary metric, while the remaining metrics provide necessary context.
 
-        The public results contain aggregate metrics and available bias-type summaries. Per-item model predictions and likelihood traces are not currently published. Results from provisional or preliminary dataset releases should be interpreted accordingly.
+        Results from provisional or preliminary dataset releases should be interpreted accordingly.
         """
         )
         with gr.Tabs():

--- a/tests/test_fairness.py
+++ b/tests/test_fairness.py
@@ -166,20 +166,23 @@ class FairnessResultsTests(unittest.TestCase):
             {
                 "StereoSet-UK Eval",
                 "WinoBias-UK Natural",
-                "WinoGender-UK",
+                "WinoPron-UK",
                 "BBQ-UK",
-                "CrowS-Pairs-UK",
             },
         )
         self.assertTrue(all(FAIRNESS_BENCHMARK_METRICS.values()))
-        self.assertLessEqual(
+        self.assertEqual(
             set(FAIRNESS_BENCHMARK_DESCRIPTIONS),
             set(FAIRNESS_BENCHMARK_METRICS),
         )
-        self.assertLessEqual(
+        self.assertEqual(
             set(FAIRNESS_BENCHMARK_RELEASE_NOTES),
             set(FAIRNESS_BENCHMARK_METRICS),
         )
+        for benchmark_name, metrics in FAIRNESS_BENCHMARK_METRICS.items():
+            description = FAIRNESS_BENCHMARK_DESCRIPTIONS[benchmark_name]
+            for metric in metrics:
+                self.assertIn(metric, description)
 
 
 if __name__ == "__main__":

--- a/tests/test_fairness.py
+++ b/tests/test_fairness.py
@@ -4,7 +4,9 @@ import unittest
 from pathlib import Path
 
 from fairness import (
+    FAIRNESS_BENCHMARK_DESCRIPTIONS,
     FAIRNESS_BENCHMARK_METRICS,
+    FAIRNESS_BENCHMARK_RELEASE_NOTES,
     FairnessBenchmark,
     FairnessRanking,
     load_fairness_benchmarks,
@@ -28,6 +30,22 @@ def stereoset_result(icat: float = 70.0) -> dict:
                 "scores": {"LMS ↑": 60.0, "SS → 50": 40.0, "ICAT ↑": 55.0},
             }
         ],
+    }
+
+
+def winobias_result(worst_group_accuracy: float = 72.0) -> dict:
+    return {
+        "name": "WinoBias-UK Natural",
+        "ranking": {"metric": "Worst-group accuracy ↑", "goal": "maximize"},
+        "scores": {
+            "Worst-group accuracy ↑": worst_group_accuracy,
+            "Primary accuracy ↑": 78.0,
+            "Pro/anti gap → 0": 12.0,
+            "Pair consistency ↑": 68.0,
+            "Agreement control ↑": 99.0,
+            "Cross control ↑": 91.0,
+            "Tie rate → 0": 0.0,
+        },
     }
 
 
@@ -83,6 +101,25 @@ class FairnessResultsTests(unittest.TestCase):
             [{"Model": "example/model", "Accuracy ↑": 81.46}],
         )
 
+    def test_loads_winobias_natural_metrics(self):
+        with tempfile.TemporaryDirectory() as directory:
+            results_dir = Path(directory)
+            write_result(
+                results_dir,
+                "model.json",
+                "example/model",
+                [stereoset_result(), winobias_result()],
+            )
+
+            benchmarks = load_fairness_benchmarks(results_dir)
+
+        winobias = benchmarks["WinoBias-UK Natural"]
+        self.assertEqual(
+            winobias.ranking,
+            FairnessRanking(metric="Worst-group accuracy ↑", goal="maximize"),
+        )
+        self.assertEqual(winobias.overall_rows[0]["Pro/anti gap → 0"], 12.0)
+
     def test_rejects_duplicate_model_results(self):
         with tempfile.TemporaryDirectory() as directory:
             results_dir = Path(directory)
@@ -128,13 +165,21 @@ class FairnessResultsTests(unittest.TestCase):
             set(FAIRNESS_BENCHMARK_METRICS),
             {
                 "StereoSet-UK Eval",
-                "WinoBias-UK",
+                "WinoBias-UK Natural",
                 "WinoGender-UK",
                 "BBQ-UK",
                 "CrowS-Pairs-UK",
             },
         )
         self.assertTrue(all(FAIRNESS_BENCHMARK_METRICS.values()))
+        self.assertLessEqual(
+            set(FAIRNESS_BENCHMARK_DESCRIPTIONS),
+            set(FAIRNESS_BENCHMARK_METRICS),
+        )
+        self.assertLessEqual(
+            set(FAIRNESS_BENCHMARK_RELEASE_NOTES),
+            set(FAIRNESS_BENCHMARK_METRICS),
+        )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

- add WinoBias-UK Natural to the fairness benchmark tabs
- replace the obsolete WinoGender-UK and CrowS-Pairs-UK placeholders with WinoPron-UK
- keep BBQ-UK in the fairness benchmark configuration
- explain every metric directly in its benchmark tab, including the preferred direction
- define the section as social-bias evaluation

## Scope

The fairness section measures social bias expressed through model preferences, coreference decisions, and question answering. Bias detection and general ethical-alignment evaluation are outside its scope. [UAlign](https://aclanthology.org/2025.unlp-1.4/) covers the broader Ukrainian alignment setting.

Each benchmark uses its own primary ranking metric. Supporting accuracy and bias metrics remain visible in the same tab.

## Datasets

- [StereoSet-UK Eval](https://huggingface.co/datasets/FairForget/StereoSet-UK-Eval)
- [WinoBias-UK Natural](https://huggingface.co/datasets/FairForget/WinoBias-UK-Natural)
- [WinoPron-UK](https://huggingface.co/datasets/FairForget/WinoPron-UK)
- [BBQ-UK](https://huggingface.co/datasets/FairForget/BBQ-UK)
